### PR TITLE
Job step, cloud project_name, errors and paging support

### DIFF
--- a/lando/server/cloudservice.py
+++ b/lando/server/cloudservice.py
@@ -15,12 +15,12 @@ class NovaClient(object):
     """
     Wraps up openstack nova operations.
     """
-    def __init__(self, cloud_settings):
+    def __init__(self, credentials):
         """
         Setup internal nova client based on credentials in cloud_settings
-        :param cloud_settings: config.CloudSettings: url, username, password, etc
+        :credentials: dictionary of url, username, password, etc
         """
-        nova_session = NovaClient.get_session(cloud_settings.credentials())
+        nova_session = NovaClient.get_session(credentials)
         self.nova = nvclient.Client('2', session=nova_session)
 
     @staticmethod
@@ -80,13 +80,14 @@ class CloudService(object):
     """
     Service for creating and terminating virtual machines.
     """
-    def __init__(self, config):
+    def __init__(self, config, project_name):
         """
         Setup configuration needed to connect to cloud service and
         :param config: Config config settings for vm and credentials
+        :param project_name: name of the project(tenant) which will contain our VMs
         """
         self.config = config
-        self.nova_client = NovaClient(config.cloud_settings)
+        self.nova_client = NovaClient(config.cloud_settings.credentials(project_name))
 
     def launch_instance(self, server_name, flavor_name, script_contents):
         """

--- a/lando/server/config.py
+++ b/lando/server/config.py
@@ -83,20 +83,20 @@ class CloudSettings(object):
         self.auth_url = get_or_raise_config_exception(data, 'auth_url')
         self.username = get_or_raise_config_exception(data, 'username')
         self.user_domain_name = get_or_raise_config_exception(data, 'user_domain_name')
-        self.project_name = get_or_raise_config_exception(data, 'project_name')
         self.project_domain_name = get_or_raise_config_exception(data, 'project_domain_name')
         self.password = get_or_raise_config_exception(data, 'password')
 
-    def credentials(self):
+    def credentials(self, project_name):
         """
         Make credentials for connecting to the cloud.
+        :param project_name: str: name of the project(tenant) which will contain our VMs
         :return: dict: cloud credentials read from config file
         """
         return {
           'auth_url': self.auth_url,
           'username': self.username,
           'user_domain_name': self.user_domain_name,
-          'project_name' : self.project_name,
+          'project_name' : project_name,
           'project_domain_name': self.project_domain_name,
           'password': self.password,
         }

--- a/lando/server/jobapi.py
+++ b/lando/server/jobapi.py
@@ -46,7 +46,7 @@ class BespinApi(object):
         """
         path = 'jobs/?vm_instance_name={}'.format(vm_instance_name)
         url = self._make_url(path)
-        return self._get_all_pages_results(url)
+        return self._get_results(url)
 
     def put_job(self, job_id, data):
         """
@@ -69,7 +69,7 @@ class BespinApi(object):
         """
         path = 'job-input-files/?job={}'.format(job_id)
         url = self._make_url(path)
-        return self._get_all_pages_results(url)
+        return self._get_results(url)
 
     def _make_url(self, suffix):
         return '{}/admin/{}'.format(self.settings.url, suffix)
@@ -82,7 +82,7 @@ class BespinApi(object):
         """
         path = 'dds-user-credentials/?user={}'.format(user_id)
         url = self._make_url(path)
-        return self._get_all_pages_results(url)
+        return self._get_results(url)
 
     def post_error(self, job_id, job_step, content):
         """
@@ -102,29 +102,17 @@ class BespinApi(object):
         resp.raise_for_status()
         return resp.json()
 
-    def _get_all_pages_results(self, base_url):
+    def _get_results(self, url):
         """
-        Given a url that follows JSON API pagination fetch 'results' of all pages.
-        Makes a request for each page and returns all the results when done.
-        :param base_url: str: base url which will have page=<pagenum> appended
-        :return: [dict]: list of results from all requests
+        Given a url that returns a JSON array send a GET request and return the results
+        :param url: str: url which returns a list of items
+        :return: [dict]: items returned from request
         """
         results = []
-        page_param = "&page="
-        if base_url[-1] == '/':
-            page_param = "?page="
-        fetch_page = 1
-        while True:
-            url = "{}{}{}".format(base_url, page_param, fetch_page)
-            resp = requests.get(url, headers=self.headers())
-            resp.raise_for_status()
-            json_data = resp.json()
-            results.extend(json_data["results"])
-            num_pages = json_data["meta"]["pagination"]["pages"]
-            if fetch_page >= num_pages:
-                break
-            fetch_page += 1
-        return results
+        resp = requests.get(url, headers=self.headers())
+        resp.raise_for_status()
+        json_data = resp.json()
+        return json_data
 
 
 class JobApi(object):

--- a/lando/server/jobapi.py
+++ b/lando/server/jobapi.py
@@ -3,7 +3,6 @@ Allows reading and updating job information when talking to Bespin REST api.
 """
 from __future__ import print_function
 import requests
-from requests.auth import HTTPBasicAuth
 
 
 class BespinApi(object):
@@ -15,7 +14,6 @@ class BespinApi(object):
         :param config: ServerConfig: contains settings for connecting to REST api
         """
         self.settings = config.bespin_api_settings
-        self.requests = requests # Allows mocking requests for unit testing
 
 
     def headers(self):
@@ -36,7 +34,7 @@ class BespinApi(object):
         """
         path = 'jobs/{}/'.format(job_id)
         url = self._make_url(path)
-        resp = self.requests.get(url, headers=self.headers())
+        resp = requests.get(url, headers=self.headers())
         resp.raise_for_status()
         return resp.json()
 
@@ -49,7 +47,7 @@ class BespinApi(object):
         """
         path = 'jobs/{}/'.format(job_id)
         url = self._make_url(path)
-        resp = self.requests.put(url, headers=self.headers(), json=data)
+        resp = requests.put(url, headers=self.headers(), json=data)
         resp.raise_for_status()
         return resp.json()
 
@@ -61,7 +59,7 @@ class BespinApi(object):
         """
         path = 'job-input-files/?job={}'.format(job_id)
         url = self._make_url(path)
-        resp = self.requests.get(url, headers=self.headers())
+        resp = requests.get(url, headers=self.headers())
         resp.raise_for_status()
         return resp.json()
 
@@ -76,7 +74,7 @@ class BespinApi(object):
         """
         path = 'dds-user-credentials/?user={}'.format(user_id)
         url = self._make_url(path)
-        resp = self.requests.get(url, headers=self.headers())
+        resp = requests.get(url, headers=self.headers())
         resp.raise_for_status()
         return resp.json()
 
@@ -106,6 +104,13 @@ class JobApi(object):
         :param state: str: value from JobStates
         """
         self._set_job({'state': state})
+
+    def set_job_step(self, step):
+        """
+        Change the step of the job is working on.
+        :param state: str: value from JobSteps
+        """
+        self._set_job({'step': step})
 
     def set_vm_instance_name(self, vm_instance_name):
         """
@@ -153,6 +158,7 @@ class Job(object):
         self.state = data['state']
         self.vm_flavor = data['vm_flavor']
         self.vm_instance_name = data['vm_instance_name']
+        self.vm_project_name = data['vm_project_name']
         self.workflow = Workflow(data)
         self.output_directory = OutputDirectory(data)
 
@@ -267,12 +273,19 @@ class JobStates(object):
     Values for state that must match up those supported by Bespin.
     """
     NEW = 'N'
+    RUNNING = 'R'
+    FINISHED = 'F'
+    ERRORED = 'E'
+    CANCELED = 'C'
+
+
+class JobSteps(object):
+    """
+    Values for state that must match up those supported by Bespin.
+    """
     CREATE_VM = 'V'
     STAGING = 'S'
     RUNNING = 'R'
     STORING_JOB_OUTPUT = 'O'
     TERMINATE_VM = 'T'
-    FINISHED = 'F'
-    ERRORED = 'E'
-    CANCELED = 'C'
 

--- a/lando/server/lando.py
+++ b/lando/server/lando.py
@@ -106,6 +106,8 @@ class JobActions(object):
                 self.run_job_complete(payload)
             elif job.step == JobSteps.TERMINATE_VM:
                 self.store_job_output_complete(payload)
+            else:
+                self.start_job(StartJobPayload(payload.job_id))
         else:
             self.start_job(StartJobPayload(payload.job_id))
 

--- a/lando/server/lando.py
+++ b/lando/server/lando.py
@@ -2,9 +2,8 @@
 Server that starts/terminates VMs based on messages received from a queue.
 """
 from __future__ import print_function, absolute_import
-import uuid
 from datetime import datetime
-from lando.server.jobapi import JobApi, JobStates
+from lando.server.jobapi import JobApi, JobStates, JobSteps
 from lando.server.bootscript import BootScript
 from lando.server.cloudservice import CloudService, FakeCloudService
 from lando_messaging.clients import LandoWorkerClient
@@ -28,16 +27,17 @@ class JobSettings(object):
         self.job_id = job_id
         self.config = config
 
-    def get_cloud_service(self):
+    def get_cloud_service(self, project_name):
         """
         Creates cloud service for creating and deleting VMs.
         If configuration has fake_cloud_service set to True this will create a fake cloud service for debugging purposes.
+        :param project_name: name of the project(tenant) which will contain our VMs
         :return: CloudService
         """
         if self.config.fake_cloud_service:
             return FakeCloudService(self.config)
         else:
-            return CloudService(self.config)
+            return CloudService(self.config, project_name)
 
     def get_job_api(self):
         """
@@ -63,7 +63,6 @@ class JobActions(object):
         self.settings = settings
         self.job_id = settings.job_id
         self.config = settings.config
-        self.cloud_service = settings.get_cloud_service()
         self.job_api = settings.get_job_api()
 
     def make_worker_client(self, vm_instance_name):
@@ -81,7 +80,10 @@ class JobActions(object):
         Then we wait for stage data complete message.
         :param payload:StartJobPayload contains job_id we should start
         """
-        vm_instance_name = self.cloud_service.make_vm_name(self.job_id)
+        self._set_job_state(JobStates.RUNNING)
+        job = self.job_api.get_job()
+        cloud_service = self._get_cloud_service(job)
+        vm_instance_name = cloud_service.make_vm_name(self.job_id)
         self.launch_vm(vm_instance_name)
         self.send_stage_job_message(vm_instance_name)
 
@@ -90,12 +92,13 @@ class JobActions(object):
         Sets job state to creating vm, then creates a new VM with vm_instance_name and gives it a floating IP address.
         :param vm_instance_name: str: name we should assign to the new vm
         """
-        self._set_job_state(JobStates.CREATE_VM)
+        self._set_job_step(JobSteps.CREATE_VM)
         self._show_status("Creating VM")
         worker_config_yml = self.config.make_worker_config_yml(vm_instance_name)
         boot_script = BootScript(worker_config_yml)
         job = self.job_api.get_job()
-        instance, ip_address = self.cloud_service.launch_instance(vm_instance_name, job.vm_flavor, boot_script.content)
+        cloud_service = self._get_cloud_service(job)
+        instance, ip_address = cloud_service.launch_instance(vm_instance_name, job.vm_flavor, boot_script.content)
         self._show_status("Launched vm with ip {}".format(ip_address))
         self.job_api.set_vm_instance_name(vm_instance_name)
 
@@ -104,7 +107,7 @@ class JobActions(object):
         Sets the job's state to staging and puts the stage job message into the queue for the worker with vm_instance_name.
         :param vm_instance_name: str: name of the instance we will send this message to
         """
-        self._set_job_state(JobStates.STAGING)
+        self._set_job_step(JobSteps.STAGING)
         self._show_status("Staging data")
         credentials = self.job_api.get_credentials()
         worker_client = self.make_worker_client(vm_instance_name)
@@ -116,7 +119,7 @@ class JobActions(object):
         Sets the job state to RUNNING and puts the run job message into the queue for the worker.
         :param payload: JobStepCompletePayload: contains job id and vm_instance_name
         """
-        self._set_job_state(JobStates.RUNNING)
+        self._set_job_step(JobSteps.RUNNING)
         self._show_status("Running job")
         job = self.job_api.get_job()
         worker_client = self.make_worker_client(payload.vm_instance_name)
@@ -128,7 +131,7 @@ class JobActions(object):
         Sets the job state to STORING_OUTPUT and puts the store output message into the queue for the worker.
         :param payload: JobStepCompletePayload: contains job id and vm_instance_name
         """
-        self._set_job_state(JobStates.STORING_JOB_OUTPUT)
+        self._set_job_step(JobSteps.STORING_JOB_OUTPUT)
         self._show_status("Storing job output")
         credentials = self.job_api.get_credentials()
         job = self.job_api.get_job()
@@ -141,11 +144,15 @@ class JobActions(object):
         Sets the job state to finished terminates the worker's instance and deletes the worker's queue.
         :param payload: JobStepCompletePayload: contains job id and vm_instance_name
         """
-        self._set_job_state(JobStates.FINISHED)
+        self._set_job_step(JobSteps.TERMINATE_VM)
         self._show_status("Terminating VM and queue")
-        self.cloud_service.terminate_instance(payload.vm_instance_name)
+        job = self.job_api.get_job()
+        cloud_service = self._get_cloud_service(job)
+        cloud_service.terminate_instance(payload.vm_instance_name)
         worker_client = self.make_worker_client(payload.vm_instance_name)
         worker_client.delete_queue()
+        self._set_job_state(JobStates.FINISHED)
+
 
     def cancel_job(self, payload):
         """
@@ -156,7 +163,8 @@ class JobActions(object):
         self._set_job_state(JobStates.CANCELED)
         self._show_status("Canceling job")
         job = self.job_api.get_job()
-        self.cloud_service.terminate_instance(job.vm_instance_name)
+        cloud_service = self._get_cloud_service(job)
+        cloud_service.terminate_instance(job.vm_instance_name)
         worker_client = self.make_worker_client(job.vm_instance_name)
         worker_client.delete_queue()
 
@@ -195,6 +203,12 @@ class JobActions(object):
 
     def _set_job_state(self, state):
         self.job_api.set_job_state(state)
+
+    def _set_job_step(self, step):
+        self.job_api.set_job_step(step)
+
+    def _get_cloud_service(self, job):
+        return self.settings.get_cloud_service(job.vm_project_name)
 
     def _show_status(self, message):
         format_str = "{}: {} for job: {}."

--- a/lando/server/tests/test_cloudservice.py
+++ b/lando/server/tests/test_cloudservice.py
@@ -11,7 +11,7 @@ class TestCwlWorkflow(TestCase):
     def test_that_flavor_overrides_default(self, mock_client, mock_session, mock_get_plugin_loader):
         config = mock.MagicMock()
         config.vm_settings.default_favor_name = 'm1.xbig'
-        cloud_service = CloudService(config)
+        cloud_service = CloudService(config, project_name='bespin_user1')
         cloud_service.launch_instance(server_name="worker1", flavor_name='m1.GIANT', script_contents="")
         find_flavor_method = mock_client().flavors.find
         find_flavor_method.assert_called_with(name='m1.GIANT')
@@ -22,7 +22,7 @@ class TestCwlWorkflow(TestCase):
     def test_that_no_flavor_chooses_default(self, mock_client, mock_session, mock_get_plugin_loader):
         config = mock.MagicMock()
         config.vm_settings.default_favor_name = 'm1.xbig'
-        cloud_service = CloudService(config)
+        cloud_service = CloudService(config, project_name='bespin_user1')
         cloud_service.launch_instance(server_name="worker1", flavor_name=None, script_contents="")
         find_flavor_method = mock_client().flavors.find
         find_flavor_method.assert_called_with(name='m1.xbig')

--- a/lando/server/tests/test_jobapi.py
+++ b/lando/server/tests/test_jobapi.py
@@ -1,63 +1,29 @@
 from __future__ import absolute_import
 from unittest import TestCase
 from lando.server.jobapi import JobApi
-
-
-class FakeConfig(object):
-    def __init__(self):
-        self.url = '127.0.0.1'
-        self.token = 'secretstuff'
-        self.bespin_api_settings = self
-
-
-class FakeRequests(object):
-    def __init__(self):
-        self.url_to_response = {}
-        self.last_url = None
-        self.last_json = None
-
-    def _response(self, url, headers, json=None):
-        self.last_url = url
-        self.last_json = json
-        response = self.url_to_response.get(url)
-        return response
-
-    def get(self, url, headers, json=None):
-        return self._response(url, headers, json)
-
-    def put(self, url, headers, json=None):
-        return self._response(url, headers, json)
-
-
-class FakeResponse(object):
-    def __init__(self, data):
-        self.data = data
-
-    def json(self):
-        return self.data
-
-    def raise_for_status(self):
-        pass
+from mock.mock import MagicMock, patch
 
 
 class TestJobApi(TestCase):
-    def setup_job_api_and_requests(self, job_id):
-        fake_requests = FakeRequests()
-        job_api = JobApi(FakeConfig(), job_id)
-        job_api.api.requests = fake_requests
-        return job_api, fake_requests
+    def setup_job_api(self, job_id):
+        mock_config = MagicMock()
+        mock_config.bespin_api_settings.url = 'APIURL'
+        job_api = JobApi(mock_config, job_id)
+        return job_api
 
-    def test_get_job_api(self):
+    @patch('lando.server.jobapi.requests')
+    def test_get_job_api(self, mock_requests):
         """
         Test requesting job status, etc
         """
-        job_api, fake_requests = self.setup_job_api_and_requests(1)
+        job_api = self.setup_job_api(1)
         job_response_payload = {
             'id': 1,
             'user_id': 23,
             'state': 'N',
             'vm_flavor': 'm1.tiny',
             'vm_instance_name': '',
+            "vm_project_name": 'jpb67',
             'workflow_input_json': '{ "value": 1 }',
             'workflow_version': {
                 'url': 'file:///mnt/fastqc.cwl',
@@ -69,13 +35,19 @@ class TestJobApi(TestCase):
                 'dds_user_credentials': '123',
             },
         }
-        fake_requests.url_to_response['127.0.0.1/jobs/1/'] = FakeResponse(job_response_payload)
+        mock_response = MagicMock()
+        mock_response.json.return_value = job_response_payload
+        mock_requests.get.return_value = mock_response
         job = job_api.get_job()
+        args, kwargs = mock_requests.get.call_args
+        self.assertEqual(args[0], 'APIURL/jobs/1/')
+
         self.assertEqual(1, job.id)
         self.assertEqual(23, job.user_id)
         self.assertEqual('N', job.state)
         self.assertEqual('m1.tiny', job.vm_flavor)
         self.assertEqual('', job.vm_instance_name)
+        self.assertEqual('jpb67', job.vm_project_name)
 
         self.assertEqual('{ "value": 1 }', job.workflow.input_json)
         self.assertEqual('file:///mnt/fastqc.cwl', job.workflow.url)
@@ -86,19 +58,41 @@ class TestJobApi(TestCase):
         self.assertEqual('1235123', job.output_directory.project_id)
         self.assertEqual('123', job.output_directory.dds_user_credentials)
 
-    def test_set_job_state(self):
-        job_api, fake_requests = self.setup_job_api_and_requests(2)
-        fake_requests.url_to_response['127.0.0.1/jobs/2/'] = FakeResponse({})
+    @patch('lando.server.jobapi.requests')
+    def test_set_job_state(self, mock_requests):
+        job_api = self.setup_job_api(2)
+        mock_response = MagicMock()
+        mock_response.json.return_value = {}
+        mock_requests.put.return_value = mock_response
         job_api.set_job_state('E')
-        self.assertEqual({'state':'E'}, fake_requests.last_json)
+        args, kwargs = mock_requests.put.call_args
+        self.assertEqual(args[0], 'APIURL/jobs/2/')
+        self.assertEqual(kwargs.get('json'), {'state': 'E'})
 
-    def test_set_vm_instance_name(self):
-        job_api, fake_requests = self.setup_job_api_and_requests(3)
-        fake_requests.url_to_response['127.0.0.1/jobs/3/'] = FakeResponse({})
+    @patch('lando.server.jobapi.requests')
+    def test_set_job_step(self, mock_requests):
+        job_api = self.setup_job_api(2)
+        mock_response = MagicMock()
+        mock_response.json.return_value = {}
+        mock_requests.put.return_value = mock_response
+        job_api.set_job_step('N')
+        args, kwargs = mock_requests.put.call_args
+        self.assertEqual(args[0], 'APIURL/jobs/2/')
+        self.assertEqual(kwargs.get('json'), {'step': 'N'})
+
+    @patch('lando.server.jobapi.requests')
+    def test_set_vm_instance_name(self, mock_requests):
+        job_api = self.setup_job_api(3)
+        mock_response = MagicMock()
+        mock_response.json.return_value = mock_response
+        mock_requests.put.return_value = mock_response
         job_api.set_vm_instance_name('worker_123')
-        self.assertEqual({'vm_instance_name': 'worker_123'}, fake_requests.last_json)
+        args, kwargs = mock_requests.put.call_args
+        self.assertEqual(args[0], 'APIURL/jobs/3/')
+        self.assertEqual(kwargs.get('json'), {'vm_instance_name': 'worker_123'})
 
-    def test_get_input_files(self):
+    @patch('lando.server.jobapi.requests')
+    def test_get_input_files(self, mock_requests):
         input_files_response_payload = [
             {
                 'file_type': 'dds_file',
@@ -125,11 +119,15 @@ class TestJobApi(TestCase):
             },
         ]
 
-        job_api, fake_requests = self.setup_job_api_and_requests(4)
-        fake_requests.url_to_response['127.0.0.1/job-input-files/?job=4'] = FakeResponse(input_files_response_payload)
+        mock_response = MagicMock()
+        mock_response.json.return_value = input_files_response_payload
+        mock_requests.get.return_value = mock_response
+        job_api = self.setup_job_api(4)
         files = job_api.get_input_files()
-        self.assertEqual(2, len(files))
+        args, kwargs = mock_requests.get.call_args
+        self.assertEqual(args[0], 'APIURL/job-input-files/?job=4')
 
+        self.assertEqual(2, len(files))
         file = files[0]
         self.assertEqual('dds_file', file.file_type)
         self.assertEqual(1, len(file.dds_files))
@@ -146,14 +144,16 @@ class TestJobApi(TestCase):
         self.assertEqual('https://stuff.com/file123.model', url_file.url)
         self.assertEqual('file123.model', url_file.destination_path)
 
-    def test_get_credentials(self):
-        job_api, fake_requests = self.setup_job_api_and_requests(4)
+    @patch('lando.server.jobapi.requests')
+    def test_get_credentials(self, mock_requests):
+        job_api = self.setup_job_api(4)
         job_response_payload = {
             'id': 4,
             'user_id': 23,
             'state': 'N',
             'vm_flavor': 'm1.tiny',
             'vm_instance_name': '',
+            "vm_project_name": 'jpb67',
             'workflow_input_json': '{ "value": 1 }',
             'workflow_version': {
                 'url': 'file:///mnt/fastqc.cwl',
@@ -179,10 +179,15 @@ class TestJobApi(TestCase):
                 }
             }
         ]
-        fake_requests.url_to_response['127.0.0.1/jobs/4/'] = FakeResponse(job_response_payload)
-        fake_requests.url_to_response['127.0.0.1/dds-user-credentials/?user=23'] = FakeResponse(user_credentials_response)
+        mock_response = MagicMock()
+        mock_response.json.side_effect = [job_response_payload, user_credentials_response]
+        mock_requests.get.return_value = mock_response
+        job_api = self.setup_job_api(4)
 
         user_credentials = job_api.get_credentials()
+        args, kwargs = mock_requests.get.call_args
+        self.assertEqual(args[0], 'APIURL/dds-user-credentials/?user=23')
+
         user_cred = user_credentials.dds_user_credentials[5]
         self.assertEqual('1239109', user_cred.token)
         self.assertEqual('2191230', user_cred.endpoint_agent_key)

--- a/lando/server/tests/test_jobapi.py
+++ b/lando/server/tests/test_jobapi.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from unittest import TestCase
-from lando.server.jobapi import JobApi
+from lando.server.jobapi import JobApi, BespinApi
 from mock.mock import MagicMock, patch
 
 
@@ -21,6 +21,7 @@ class TestJobApi(TestCase):
             'id': 1,
             'user_id': 23,
             'state': 'N',
+            'step': '',
             'vm_flavor': 'm1.tiny',
             'vm_instance_name': '',
             "vm_project_name": 'jpb67',
@@ -40,7 +41,7 @@ class TestJobApi(TestCase):
         mock_requests.get.return_value = mock_response
         job = job_api.get_job()
         args, kwargs = mock_requests.get.call_args
-        self.assertEqual(args[0], 'APIURL/jobs/1/')
+        self.assertEqual(args[0], 'APIURL/admin/jobs/1/')
 
         self.assertEqual(1, job.id)
         self.assertEqual(23, job.user_id)
@@ -66,7 +67,7 @@ class TestJobApi(TestCase):
         mock_requests.put.return_value = mock_response
         job_api.set_job_state('E')
         args, kwargs = mock_requests.put.call_args
-        self.assertEqual(args[0], 'APIURL/jobs/2/')
+        self.assertEqual(args[0], 'APIURL/admin/jobs/2/')
         self.assertEqual(kwargs.get('json'), {'state': 'E'})
 
     @patch('lando.server.jobapi.requests')
@@ -77,7 +78,7 @@ class TestJobApi(TestCase):
         mock_requests.put.return_value = mock_response
         job_api.set_job_step('N')
         args, kwargs = mock_requests.put.call_args
-        self.assertEqual(args[0], 'APIURL/jobs/2/')
+        self.assertEqual(args[0], 'APIURL/admin/jobs/2/')
         self.assertEqual(kwargs.get('json'), {'step': 'N'})
 
     @patch('lando.server.jobapi.requests')
@@ -88,36 +89,45 @@ class TestJobApi(TestCase):
         mock_requests.put.return_value = mock_response
         job_api.set_vm_instance_name('worker_123')
         args, kwargs = mock_requests.put.call_args
-        self.assertEqual(args[0], 'APIURL/jobs/3/')
+        self.assertEqual(args[0], 'APIURL/admin/jobs/3/')
         self.assertEqual(kwargs.get('json'), {'vm_instance_name': 'worker_123'})
 
     @patch('lando.server.jobapi.requests')
     def test_get_input_files(self, mock_requests):
-        input_files_response_payload = [
-            {
-                'file_type': 'dds_file',
-                'workflow_name': 'sequence',
-                'dds_files': [
-                    {
-                        'file_id': 123,
-                        'destination_path': 'seq1.fasta',
-                        'dds_user_credentials': 823,
-                    }
-                ],
-                'url_files': [],
+        input_files_response_payload = {
+            "meta": {
+                "pagination": {
+                    "page": 1,
+                    "pages": 1,
+                    "count": 1
+                }
             },
-            {
-                'file_type': 'url_file_array',
-                'workflow_name': 'models',
-                'dds_files': [],
-                'url_files': [
-                    {
-                        'url': "https://stuff.com/file123.model",
-                        'destination_path': "file123.model",
-                    }
-                ],
-            },
-        ]
+            'results': [
+                {
+                    'file_type': 'dds_file',
+                    'workflow_name': 'sequence',
+                    'dds_files': [
+                        {
+                            'file_id': 123,
+                            'destination_path': 'seq1.fasta',
+                            'dds_user_credentials': 823,
+                        }
+                    ],
+                    'url_files': [],
+                },
+                {
+                    'file_type': 'url_file_array',
+                    'workflow_name': 'models',
+                    'dds_files': [],
+                    'url_files': [
+                        {
+                            'url': "https://stuff.com/file123.model",
+                            'destination_path': "file123.model",
+                        }
+                    ],
+                },
+            ]
+        }
 
         mock_response = MagicMock()
         mock_response.json.return_value = input_files_response_payload
@@ -125,7 +135,7 @@ class TestJobApi(TestCase):
         job_api = self.setup_job_api(4)
         files = job_api.get_input_files()
         args, kwargs = mock_requests.get.call_args
-        self.assertEqual(args[0], 'APIURL/job-input-files/?job=4')
+        self.assertEqual(args[0], 'APIURL/admin/job-input-files/?job=4&page=1')
 
         self.assertEqual(2, len(files))
         file = files[0]
@@ -146,11 +156,11 @@ class TestJobApi(TestCase):
 
     @patch('lando.server.jobapi.requests')
     def test_get_credentials(self, mock_requests):
-        job_api = self.setup_job_api(4)
         job_response_payload = {
             'id': 4,
             'user_id': 23,
             'state': 'N',
+            'step': '',
             'vm_flavor': 'm1.tiny',
             'vm_instance_name': '',
             "vm_project_name": 'jpb67',
@@ -166,19 +176,29 @@ class TestJobApi(TestCase):
                 'dds_user_credentials': '123',
             },
         }
-        user_credentials_response = [
-            {
-                'id': 5,
-                'user': 23,
-                'token': '1239109',
-                'endpoint': {
-                    'id': 3,
-                    'name': 'dukeds',
-                    'agent_key': '2191230',
-                    'api_root': 'localhost/api/v1/',
+        user_credentials_response = {
+            "meta": {
+                "pagination": {
+                    "page": 1,
+                    "pages": 1,
+                    "count": 1
                 }
-            }
-        ]
+            },
+            'results': [
+                {
+                    'id': 5,
+                    'user': 23,
+                    'token': '1239109',
+                    'endpoint': {
+                        'id': 3,
+                        'name': 'dukeds',
+                        'agent_key': '2191230',
+                        'api_root': 'localhost/api/v1/',
+                    }
+                }
+            ]
+        }
+
         mock_response = MagicMock()
         mock_response.json.side_effect = [job_response_payload, user_credentials_response]
         mock_requests.get.return_value = mock_response
@@ -186,9 +206,221 @@ class TestJobApi(TestCase):
 
         user_credentials = job_api.get_credentials()
         args, kwargs = mock_requests.get.call_args
-        self.assertEqual(args[0], 'APIURL/dds-user-credentials/?user=23')
+        self.assertEqual(args[0], 'APIURL/admin/dds-user-credentials/?user=23&page=1')
 
         user_cred = user_credentials.dds_user_credentials[5]
         self.assertEqual('1239109', user_cred.token)
         self.assertEqual('2191230', user_cred.endpoint_agent_key)
         self.assertEqual('localhost/api/v1/', user_cred.endpoint_api_root)
+
+
+    @patch('lando.server.jobapi.requests')
+    def test_get_jobs_for_vm_instance_name(self, mock_requests):
+        jobs_response = {
+            "meta": {
+                "pagination": {
+                    "page": 1,
+                    "pages": 1,
+                    "count": 1
+                }
+            },
+            'results': [
+                {
+                    'id': 1,
+                    'user_id': 23,
+                    'state': 'N',
+                    'step': '',
+                    'vm_flavor': 'm1.tiny',
+                    'vm_instance_name': '',
+                    "vm_project_name": 'jpb67',
+                    'workflow_input_json': '{ "value": 1 }',
+                    'workflow_version': {
+                        'url': 'file:///mnt/fastqc.cwl',
+                        'object_name': '#main',
+                    },
+                    'output_dir': {
+                        'dir_name': 'results',
+                        'project_id': '1235123',
+                        'dds_user_credentials': '123',
+                    },
+                }
+            ]
+        }
+        mock_config = MagicMock()
+        mock_config.bespin_api_settings.url = 'APIURL'
+
+        mock_response = MagicMock()
+        mock_response.json.side_effect = [jobs_response]
+        mock_requests.get.return_value = mock_response
+        jobs = JobApi.get_jobs_for_vm_instance_name(mock_config, 'joe')
+        self.assertEqual(1, len(jobs))
+
+    @patch('lando.server.jobapi.requests')
+    def test_post_error(self, mock_requests):
+        mock_response = MagicMock()
+        mock_response.json.return_value = {}
+        mock_requests.get.return_value = mock_response
+        job_api = self.setup_job_api(4)
+        job_api.save_error_details('V', 'Out of memory')
+        args, kwargs = mock_requests.post.call_args
+        self.assertEqual(args[0], 'APIURL/admin/job-errors/')
+        self.assertEqual(kwargs['json']['job'], 4)
+        self.assertEqual(kwargs['json']['job_step'], 'V')
+        self.assertEqual(kwargs['json']['content'], 'Out of memory')
+
+    @patch('lando.server.jobapi.requests')
+    def test_one_page_result(self, mock_requests):
+        jobs_response = {
+            "meta": {
+                "pagination": {
+                    "page": 1,
+                    "pages": 1,
+                    "count": 3
+                }
+            },
+            'results': [
+                {
+                    'id': 1
+                },
+                {
+                    'id': 2
+                },
+                {
+                    'id': 3
+                },
+            ]
+        }
+        mock_config = MagicMock()
+        mock_config.bespin_api_settings.url = 'APIURL'
+        mock_response = MagicMock()
+        mock_response.json.side_effect = [jobs_response]
+        mock_requests.get.return_value = mock_response
+        items = BespinApi(mock_config)._get_all_pages_results('APIURL/items/')
+        args, kwargs = mock_requests.get.call_args
+        self.assertEqual(args[0], 'APIURL/items/?page=1')
+        self.assertEqual(3, len(items))
+        self.assertEqual(1, items[0]['id'])
+        self.assertEqual(2, items[1]['id'])
+        self.assertEqual(3, items[2]['id'])
+
+    @patch('lando.server.jobapi.requests')
+    def test_two_page_result(self, mock_requests):
+        jobs_response1 = {
+            "meta": {
+                "pagination": {
+                    "page": 1,
+                    "pages": 2,
+                }
+            },
+            'results': [
+                {
+                    'id': 1
+                },
+                {
+                    'id': 2
+                },
+                {
+                    'id': 3
+                },
+            ]
+        }
+        jobs_response2 = {
+            "meta": {
+                "pagination": {
+                    "page": 2,
+                    "pages": 2,
+                }
+            },
+            'results': [
+                {
+                    'id': 4
+                },
+                {
+                    'id': 5
+                },
+            ]
+        }
+        mock_config = MagicMock()
+        mock_config.bespin_api_settings.url = 'APIURL'
+        mock_response = MagicMock()
+        mock_response.json.side_effect = [jobs_response1, jobs_response2]
+        mock_requests.get.return_value = mock_response
+        items = BespinApi(mock_config)._get_all_pages_results('APIURL/items/')
+        args, kwargs = mock_requests.get.call_args
+        self.assertEqual(args[0], 'APIURL/items/?page=2')
+        self.assertEqual(5, len(items))
+        self.assertEqual(1, items[0]['id'])
+        self.assertEqual(2, items[1]['id'])
+        self.assertEqual(3, items[2]['id'])
+        self.assertEqual(4, items[3]['id'])
+        self.assertEqual(5, items[4]['id'])
+
+    @patch('lando.server.jobapi.requests')
+    def test_three_page_result(self, mock_requests):
+        jobs_response1 = {
+            "meta": {
+                "pagination": {
+                    "page": 1,
+                    "pages": 3,
+                }
+            },
+            'results': [
+                {
+                    'id': 1
+                },
+                {
+                    'id': 2
+                },
+                {
+                    'id': 3
+                },
+            ]
+        }
+        jobs_response2 = {
+            "meta": {
+                "pagination": {
+                    "page": 2,
+                    "pages": 3,
+                }
+            },
+            'results': [
+                {
+                    'id': 4
+                },
+                {
+                    'id': 5
+                },
+                {
+                    'id': 6
+                },
+            ]
+        }
+        jobs_response3 = {
+            "meta": {
+                "pagination": {
+                    "page": 3,
+                    "pages": 3,
+                }
+            },
+            'results': [
+                {
+                    'id': 7
+                },
+            ]
+        }
+        mock_config = MagicMock()
+        mock_config.bespin_api_settings.url = 'APIURL'
+        mock_response = MagicMock()
+        mock_response.json.side_effect = [jobs_response1, jobs_response2, jobs_response3]
+        mock_requests.get.return_value = mock_response
+        items = BespinApi(mock_config)._get_all_pages_results('APIURL/items/')
+        args, kwargs = mock_requests.get.call_args
+        self.assertEqual(args[0], 'APIURL/items/?page=3')
+        self.assertEqual(7, len(items))
+        self.assertEqual(1, items[0]['id'])
+        self.assertEqual(2, items[1]['id'])
+        self.assertEqual(3, items[2]['id'])
+        self.assertEqual(4, items[3]['id'])
+        self.assertEqual(5, items[4]['id'])
+        self.assertEqual(6, items[5]['id'])
+        self.assertEqual(7, items[6]['id'])

--- a/lando/server/tests/test_lando.py
+++ b/lando/server/tests/test_lando.py
@@ -370,4 +370,3 @@ Delete my worker's queue.
 Set job state to F.
         """
         self.assertMultiLineEqual(expected_report.strip(), report.text.strip())
-g

--- a/lando/server/tests/test_lando.py
+++ b/lando/server/tests/test_lando.py
@@ -140,8 +140,23 @@ Created vm name for job 1.
 Set job step to V.
 Launched vm worker_x.
 Set vm instance name to worker_x.
+        """
+        self.assertMultiLineEqual(expected_report.strip(), report.text.strip())
+
+    @patch('lando.server.lando.JobApi')
+    @patch('lando.server.lando.JobSettings')
+    @patch('lando.server.lando.LandoWorkerClient')
+    @patch('lando.server.jobapi.requests')
+    def test_worker_started(self, mock_requests, MockLandoWorkerClient, MockJobSettings, MockJobApi):
+        MockJobApi.get_jobs_for_vm_instance_name.return_value = [MagicMock(state="R", step="V")]
+        job_id = 1
+        mock_settings, report = make_mock_settings_and_report(job_id)
+        MockJobSettings.return_value = mock_settings
+        lando = Lando(MagicMock())
+        lando.worker_started(MagicMock(worker_queue_name='stuff'))
+        expected_report = """
 Set job step to S.
-Put stage message in queue for worker_x.
+Put stage message in queue for stuff.
         """
         self.assertMultiLineEqual(expected_report.strip(), report.text.strip())
 

--- a/lando/worker/worker.py
+++ b/lando/worker/worker.py
@@ -142,6 +142,7 @@ class LandoWorker(object):
         Blocks and waits for messages on the queue specified in config.
         """
         router = self._make_router()
+        self.client.worker_started(router.queue_name)
         print("Lando worker listening for messages on queue '{}'.".format(router.queue_name))
         router.run()
 


### PR DESCRIPTION
## JobApi
Added method to set job step.
Separate job state from job step.
State: NEW, RUNNING, FINISHED, ERRORED, CANCELED
Step: CREATE_VM, STAGING, RUNNING, STORING_JOB_OUTPUT, TERMINATE_VM
Simplified based on using mock in unit tests.
Added method to get jobs based on vm_instance_name for worker_started.
Added method to save errors back to bespin-api.
Added method to get all pages for a url that supports paging.
Rewrote tests to use mock.

## CloudService
CloudService now receives a project name to specify VM allocation/billing.
server.Config now creates cloud credentials based on  project name arg.

## Lando
Set job step and state.
Changed start job to only create vm (first step).
Added method to handle worker_started to send stage data message (second step).
Added method to handle restart job.
Save errors back to bespin-api.
Rewrote tests to use mock.

## LandoWorker
Sends worker_started message when starts up(necessary for job step accuracy).
