### PR TITLE
Send job progress notifications to rabbit job_status exchange

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,5 +2,4 @@ dependencies:
   pre:
     - pip install mock
     - pip install pbr
-    - pip install -U pkg_resources 
     - pip install git+git://github.com/Duke-GCB/lando-messaging.git

--- a/circle.yml
+++ b/circle.yml
@@ -2,4 +2,4 @@ dependencies:
   pre:
     - pip install mock
     - pip install pbr
-    - pip install git+git://github.com/Duke-GCB/lando-messaging.git
+    - pip install --upgrade git+git://github.com/Duke-GCB/lando-messaging.git

--- a/circle.yml
+++ b/circle.yml
@@ -2,3 +2,5 @@ dependencies:
   pre:
     - pip install mock
     - pip install pbr
+    - pip install -U pkg_resources 
+    - pip install git+git://github.com/Duke-GCB/lando-messaging.git

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,4 @@
 dependencies:
   pre:
     - pip install mock
+    - pip install pbr

--- a/lando/server/tests/test_cwlworkflow.py
+++ b/lando/server/tests/test_cwlworkflow.py
@@ -46,8 +46,8 @@ class TestCwlWorkflow(TestCase):
             cwl_base_command = [
                 "cwl-runner",
                 "--debug",
-                "--tmpdir-prefix=/Users/jpb67",
-                "--tmp-outdir-prefix=/Users/jpb67",
+                "--tmpdir-prefix=/Users/jpb67/tmp/",
+                "--tmp-outdir-prefix=/Users/jpb67/tmp/",
             ]
         workflow_directory = tempfile.mkdtemp()
         cwl_path = os.path.join(workflow_directory, 'workflow.cwl')

--- a/lando/server/tests/test_cwlworkflow.py
+++ b/lando/server/tests/test_cwlworkflow.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from unittest import TestCase
 import os
+import pwd
 import platform
 import tempfile
 import shutil
@@ -25,6 +26,10 @@ outputs:
     type: stdout
 """
 
+# Temp directory in users home directory needed to run cwl on OSX
+USERNAME = pwd.getpwuid(os.getuid())[0]
+USER_TEMP_DIR = "/Users/" + USERNAME + "/Documents/"
+
 
 class TestCwlWorkflow(TestCase):
     def make_input_files(self, input_file_directory):
@@ -46,8 +51,8 @@ class TestCwlWorkflow(TestCase):
             cwl_base_command = [
                 "cwl-runner",
                 "--debug",
-                "--tmpdir-prefix=/Users/jpb67/tmp/",
-                "--tmp-outdir-prefix=/Users/jpb67/tmp/",
+                "--tmpdir-prefix=" + USER_TEMP_DIR,
+                "--tmp-outdir-prefix=" + USER_TEMP_DIR,
             ]
         workflow_directory = tempfile.mkdtemp()
         cwl_path = os.path.join(workflow_directory, 'workflow.cwl')
@@ -89,8 +94,8 @@ outputfile: results.txt
             cwl_base_command = [
                 "cwl-runner",
                 "--debug",
-                "--tmpdir-prefix=/Users/jpb67",
-                "--tmp-outdir-prefix=/Users/jpb67",
+                "--tmpdir-prefix=" + USER_TEMP_DIR,
+                "--tmp-outdir-prefix=" + USER_TEMP_DIR,
             ]
         workflow_directory = tempfile.mkdtemp()
         cwl_path = os.path.join(workflow_directory, 'workflow.cwl')

--- a/lando/server/tests/test_cwlworkflow.py
+++ b/lando/server/tests/test_cwlworkflow.py
@@ -26,10 +26,6 @@ outputs:
     type: stdout
 """
 
-# Temp directory in users home directory needed to run cwl on OSX
-USERNAME = pwd.getpwuid(os.getuid())[0]
-USER_TEMP_DIR = "/Users/" + USERNAME + "/Documents/"
-
 
 class TestCwlWorkflow(TestCase):
     def make_input_files(self, input_file_directory):
@@ -47,13 +43,6 @@ class TestCwlWorkflow(TestCase):
         working_directory = tempfile.mkdtemp()
         output_directory = 'result'
         cwl_base_command = None
-        if platform.system() == 'Darwin':
-            cwl_base_command = [
-                "cwl-runner",
-                "--debug",
-                "--tmpdir-prefix=" + USER_TEMP_DIR,
-                "--tmp-outdir-prefix=" + USER_TEMP_DIR,
-            ]
         workflow_directory = tempfile.mkdtemp()
         cwl_path = os.path.join(workflow_directory, 'workflow.cwl')
         text_to_file(SAMPLE_WORKFLOW, cwl_path)
@@ -90,13 +79,6 @@ outputfile: results.txt
         working_directory = tempfile.mkdtemp()
         output_directory = 'result'
         cwl_base_command = None
-        if platform.system() == 'Darwin':
-            cwl_base_command = [
-                "cwl-runner",
-                "--debug",
-                "--tmpdir-prefix=" + USER_TEMP_DIR,
-                "--tmp-outdir-prefix=" + USER_TEMP_DIR,
-            ]
         workflow_directory = tempfile.mkdtemp()
         cwl_path = os.path.join(workflow_directory, 'workflow.cwl')
         text_to_file(SAMPLE_WORKFLOW, cwl_path)

--- a/lando/worker/tests/test_worker.py
+++ b/lando/worker/tests/test_worker.py
@@ -99,7 +99,7 @@ class FakeFileData(object):
 class FakeWorkflow(object):
     def __init__(self):
         self.url = "file:///tmp/test.cwl"
-        self.input_json = "{'id':1}"
+        self.job_order = "{'id':1}"
         self.output_directory = None
         self.object_name = "#main"
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 LANDO_REQUIREMENTS = [
-      "cwlref-runner==1.0"
+      "cwlref-runner==1.0",
       "DukeDSClient",
       "keystoneauth1>=2.11.0",
       "lando-messaging",

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup, find_packages
 
 
 LANDO_REQUIREMENTS = [
+      "cwlref-runner==1.0"
       "DukeDSClient",
       "keystoneauth1>=2.11.0",
       "lando-messaging",


### PR DESCRIPTION
Places {"job":<id>,"state":<state>,"step":<step>} into job_status exchange.
This will be picked up by bespin-job-watcher and broadcasted to websockets subscribed to this job.