### PR TITLE
Release floating ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ vm_settings:
   floating_ip_pool_name: ext-net     # Pool of floating IP's that will have one assigned to the VM
   default_favor_name: m1.small       # Flavor of image to use by default when creating a VM
 
-
 # General Openstack settings
 cloud_settings:
   auth_url: http://10.109.252.9:5000/v3

--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ vm_settings:
   worker_image_name: lando_worker    # Name of the image that has lando installed and lando_worker setup to run as a service
   ssh_key_name: jpb67                # Name of the openstack SSH key to install on the worker
   network_name: selfservice          # Openstack network name to add the vm onto
+  allocate_floating_ips: false       # Should each worker VM get allocated a floating IP defaults to false
   floating_ip_pool_name: ext-net     # Pool of floating IP's that will have one assigned to the VM
   default_favor_name: m1.small       # Flavor of image to use by default when creating a VM
+
 
 # General Openstack settings
 cloud_settings:
@@ -97,7 +99,7 @@ cloud_settings:
   password: secret3  
   user_domain_name: Default               
   project_name: jpb67               # name of the project we will add VMs to
-  project_domain_name: Default    
+  project_domain_name: Default
 
 # Bespin job API settings
 bespin_api:

--- a/lando/server/config.py
+++ b/lando/server/config.py
@@ -71,6 +71,7 @@ class VMSettings(object):
         self.worker_image_name = get_or_raise_config_exception(data, 'worker_image_name')
         self.ssh_key_name = get_or_raise_config_exception(data, 'ssh_key_name')
         self.network_name = get_or_raise_config_exception(data, 'network_name')
+        self.allocate_floating_ips = data.get('allocate_floating_ips', False)
         self.floating_ip_pool_name = get_or_raise_config_exception(data, 'floating_ip_pool_name')
         self.default_favor_name = get_or_raise_config_exception(data, 'default_favor_name')
 

--- a/lando/server/tests/test_cloudservice.py
+++ b/lando/server/tests/test_cloudservice.py
@@ -1,14 +1,16 @@
 from __future__ import absolute_import
 from unittest import TestCase
+import novaclient.exceptions
 from lando.server.cloudservice import CloudService
 import mock
 
 
 class TestCwlWorkflow(TestCase):
+    @mock.patch('lando.server.cloudservice.sleep')
     @mock.patch('keystoneauth1.loading.get_plugin_loader')
     @mock.patch('keystoneauth1.session.Session')
     @mock.patch('novaclient.client.Client')
-    def test_that_flavor_overrides_default(self, mock_client, mock_session, mock_get_plugin_loader):
+    def test_that_flavor_overrides_default(self, mock_client, mock_session, mock_get_plugin_loader, mock_sleep):
         config = mock.MagicMock()
         config.vm_settings.default_favor_name = 'm1.xbig'
         cloud_service = CloudService(config, project_name='bespin_user1')
@@ -16,10 +18,11 @@ class TestCwlWorkflow(TestCase):
         find_flavor_method = mock_client().flavors.find
         find_flavor_method.assert_called_with(name='m1.GIANT')
 
+    @mock.patch('lando.server.cloudservice.sleep')
     @mock.patch('keystoneauth1.loading.get_plugin_loader')
     @mock.patch('keystoneauth1.session.Session')
     @mock.patch('novaclient.client.Client')
-    def test_that_no_flavor_chooses_default(self, mock_client, mock_session, mock_get_plugin_loader):
+    def test_that_no_flavor_chooses_default(self, mock_client, mock_session, mock_get_plugin_loader, mock_sleep):
         config = mock.MagicMock()
         config.vm_settings.default_favor_name = 'm1.xbig'
         cloud_service = CloudService(config, project_name='bespin_user1')
@@ -27,5 +30,69 @@ class TestCwlWorkflow(TestCase):
         find_flavor_method = mock_client().flavors.find
         find_flavor_method.assert_called_with(name='m1.xbig')
 
+    @mock.patch('lando.server.cloudservice.sleep')
+    @mock.patch('keystoneauth1.loading.get_plugin_loader')
+    @mock.patch('keystoneauth1.session.Session')
+    @mock.patch('novaclient.client.Client')
+    def test_launch_instance_no_floating_ip(self, mock_client, mock_session, mock_get_plugin_loader, mock_sleep):
+        config = mock.MagicMock()
+        config.vm_settings.allocate_floating_ips = False
+        config.vm_settings.default_favor_name = 'm1.large'
+        cloud_service = CloudService(config, project_name='bespin_user1')
+        instance, ip_address = cloud_service.launch_instance(server_name="worker1", flavor_name=None, script_contents="")
+        self.assertEqual(None, ip_address)
+        mock_client().servers.create.assert_called()
+        mock_client().floating_ips.create.assert_not_called()
 
+    @mock.patch('lando.server.cloudservice.sleep')
+    @mock.patch('keystoneauth1.loading.get_plugin_loader')
+    @mock.patch('keystoneauth1.session.Session')
+    @mock.patch('novaclient.client.Client')
+    def test_launch_instance_with_floating_ip(self, mock_client, mock_session, mock_get_plugin_loader, mock_sleep):
+        config = mock.MagicMock()
+        config.vm_settings.allocate_floating_ips = True
+        config.vm_settings.default_favor_name = 'm1.large'
+        cloud_service = CloudService(config, project_name='bespin_user1')
+        instance, ip_address = cloud_service.launch_instance(server_name="worker1", flavor_name=None,
+                                                             script_contents="")
+        self.assertNotEqual(None, ip_address)
+        mock_client().servers.create.assert_called()
+        mock_client().floating_ips.create.assert_called()
 
+    @mock.patch('keystoneauth1.loading.get_plugin_loader')
+    @mock.patch('keystoneauth1.session.Session')
+    @mock.patch('novaclient.client.Client')
+    def test_terminate_instance_no_floating_ip(self, mock_client, mock_session, mock_get_plugin_loader):
+        config = mock.MagicMock()
+        config.vm_settings.allocate_floating_ips = False
+        config.vm_settings.default_favor_name = 'm1.large'
+        cloud_service = CloudService(config, project_name='bespin_user1')
+        cloud_service.terminate_instance(server_name='worker1')
+        mock_client().servers.delete.assert_called()
+        mock_client().floating_ips.find.assert_not_called()
+
+    @mock.patch('keystoneauth1.loading.get_plugin_loader')
+    @mock.patch('keystoneauth1.session.Session')
+    @mock.patch('novaclient.client.Client')
+    def test_terminate_instance_with_floating_ip(self, mock_client, mock_session, mock_get_plugin_loader):
+        config = mock.MagicMock()
+        config.vm_settings.allocate_floating_ips = True
+        config.vm_settings.default_favor_name = 'm1.large'
+        cloud_service = CloudService(config, project_name='bespin_user1')
+        cloud_service.terminate_instance(server_name='worker1')
+        mock_client().servers.delete.assert_called()
+        mock_client().floating_ips.find.assert_called()
+        mock_client().floating_ips.find().delete.assert_called()
+
+    @mock.patch('keystoneauth1.loading.get_plugin_loader')
+    @mock.patch('keystoneauth1.session.Session')
+    @mock.patch('novaclient.client.Client')
+    def test_terminate_instance_with_missing_floating_ip(self, mock_client, mock_session, mock_get_plugin_loader):
+        mock_client().floating_ips.find.side_effect = novaclient.exceptions.NotFound(404)
+        config = mock.MagicMock()
+        config.vm_settings.allocate_floating_ips = True
+        config.vm_settings.default_favor_name = 'm1.large'
+        cloud_service = CloudService(config, project_name='bespin_user1')
+        cloud_service.terminate_instance(server_name='worker1')
+        mock_client().servers.delete.assert_called()
+        mock_client().floating_ips.find.assert_called()

--- a/lando/server/tests/test_config.py
+++ b/lando/server/tests/test_config.py
@@ -19,6 +19,7 @@ vm_settings:
   network_name: selfservice
   floating_ip_pool_name: ext-net
   default_favor_name: m1.small
+{}
 
 cloud_settings:
   auth_url: http://10.109.252.9:5000/v3
@@ -36,7 +37,7 @@ bespin_api:
 
 class TestServerConfig(TestCase):
     def test_good_config(self):
-        filename = write_temp_return_filename(GOOD_CONFIG)
+        filename = write_temp_return_filename(GOOD_CONFIG.format(""))
         config = ServerConfig(filename)
         os.unlink(filename)
         self.assertEqual(False, config.fake_cloud_service)
@@ -46,6 +47,8 @@ class TestServerConfig(TestCase):
 
         self.assertEqual('lando_worker', config.vm_settings.worker_image_name)
         self.assertEqual('jpb67', config.vm_settings.ssh_key_name)
+        #  by default allocate_floating_ips is off
+        self.assertEqual(False, config.vm_settings.allocate_floating_ips)
 
         self.assertEqual("http://10.109.252.9:5000/v3", config.cloud_settings.auth_url)
         self.assertEqual("jpb67", config.cloud_settings.username)
@@ -53,8 +56,22 @@ class TestServerConfig(TestCase):
         self.assertEqual("http://localhost:8000/api", config.bespin_api_settings.url)
         self.assertEqual("10498124091240e", config.bespin_api_settings.token)
 
+    def test_allocate_floating_ip_true(self):
+        line = "  allocate_floating_ips: true"
+        filename = write_temp_return_filename(GOOD_CONFIG.format(line))
+        config = ServerConfig(filename)
+        os.unlink(filename)
+        self.assertEqual(True, config.vm_settings.allocate_floating_ips)
+
+    def test_allocate_floating_ip_false(self):
+        line = "  allocate_floating_ips: false"
+        filename = write_temp_return_filename(GOOD_CONFIG.format(line))
+        config = ServerConfig(filename)
+        os.unlink(filename)
+        self.assertEqual(False, config.vm_settings.allocate_floating_ips)
+
     def test_good_config_with_fake_cloud_service(self):
-        config_data = GOOD_CONFIG + "\nfake_cloud_service: True"
+        config_data = GOOD_CONFIG.format("") + "\nfake_cloud_service: True"
         filename = write_temp_return_filename(config_data)
         config = ServerConfig(filename)
         os.unlink(filename)
@@ -73,7 +90,7 @@ class TestServerConfig(TestCase):
         os.unlink(filename)
 
     def test_make_worker_config_yml(self):
-        filename = write_temp_return_filename(GOOD_CONFIG)
+        filename = write_temp_return_filename(GOOD_CONFIG.format(""))
         config = ServerConfig(filename)
         os.unlink(filename)
         expected = """


### PR DESCRIPTION
## Delete floating ip on vm terminate
Previously floating ip addresses were allocated and not deleted at VM termination.
Now the lando server will delete the floating ip address attached to a VM.
This floating ip is allocated and attached during VM creation.
Fixes #5

## Flag to turn off floating ip allocation
Also adds a `allocate_floating_ips` to the `vm_settings` part of `/etc/lando_config.yml` which turns on/off floating ip address allocation.  Creating a floating IP address for each instance VM is not necessary for the worker to perform it's job.