### PR TITLE
Docker: install current verison of lando_messaging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Runs master branch from github of lando/lando-messaging
 # Requires a lando config file mounted at /etc/lando_config.yml.
 FROM python:2.7.13
-RUN pip install git+git://github.com/Duke-GCB/lando-messaging.git
+RUN pip install --upgrade git+git://github.com/Duke-GCB/lando-messaging.git
 ADD . /src
 WORKDIR /src
 RUN python setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@
 FROM python:2.7.13
 ADD . /src
 WORKDIR /src
-RUN pip install --upgrade git+git://github.com/Duke-GCB/lando-messaging.git
+# make sure old version is not cached after local src changes
+RUN pip install git+git://github.com/Duke-GCB/lando-messaging.git
 RUN python setup.py install
 ENV WORKDIR /work
 RUN mkdir ${WORKDIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Runs master branch from github of lando/lando-messaging
 # Requires a lando config file mounted at /etc/lando_config.yml.
 FROM python:2.7.13
-RUN pip install --upgrade git+git://github.com/Duke-GCB/lando-messaging.git
 ADD . /src
 WORKDIR /src
+RUN pip install --upgrade git+git://github.com/Duke-GCB/lando-messaging.git
 RUN python setup.py install
 ENV WORKDIR /work
 RUN mkdir ${WORKDIR}


### PR DESCRIPTION
The current version didn't upgrade lando-messaging to 0.4.
After this change it installs the latest.