### PR TITLE
Fix for circleci installing python packages

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,4 +2,5 @@ dependencies:
   pre:
     - pip install mock
     - pip install pbr
+    - pip install shade
     - pip install --upgrade git+git://github.com/Duke-GCB/lando-messaging.git

--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 dependencies:
   pre:
+    - pip install --upgrade setuptools
     - pip install mock
     - pip install pbr
     - pip install --upgrade git+git://github.com/Duke-GCB/lando-messaging.git

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,5 @@
 dependencies:
   pre:
-    - pip install --upgrade setuptools
     - pip install mock
     - pip install pbr
     - pip install --upgrade git+git://github.com/Duke-GCB/lando-messaging.git

--- a/lando/worker/tests/test_cwlworkflow.py
+++ b/lando/worker/tests/test_cwlworkflow.py
@@ -11,6 +11,7 @@ from lando.exceptions import JobStepFailed
 
 SAMPLE_WORKFLOW = """
 {
+    "cwlVersion": "v1.0",
     "class": "CommandLineTool",
     "baseCommand": "cat",
     "stdout": "$(inputs.outputfile)",

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from setuptools import setup, find_packages
 
 
 LANDO_REQUIREMENTS = [
+      "keystoneauth1>=2.20.0",
+      "python-novaclient>=7.1.0", 
       "cwlref-runner==1.0",
       "DukeDSClient",
       "humanfriendly==2.4",
       "Jinja2==2.9.5",
-      "keystoneauth1>=2.11.0",
       "lando-messaging",
       "python-dateutil==2.6.0",
-      "python-novaclient>=2.21.0,!=2.27.0,!=2.32.0",
       "PyYAML==3.11",
       "requests==2.10.0",
 ]


### PR DESCRIPTION
Circleci was failing to run `python setup.py install`.
This was the error:
```
keystoneauth1-2.20.0/setup.cfg: TypeError: dist must be a Distribution instance
```
The python openstack dependencies/pbr seem to occasionally have this problem.
In the past I fixed this by seeing how shade installs the python openstack dependancies and duplicating that process (Shade is a higher level python module for working with openstack).

It installs fine for me locally in a new virtualenv.

The fix here is to let shade handle installing the dependancies. In the near future we should switch to shade as it also has a more robust/easier api.
