### PR TITLE
Switching from nova to shade

### DIFF
--- a/lando/server/cloudservice.py
+++ b/lando/server/cloudservice.py
@@ -1,40 +1,26 @@
 """
 Allows launching and terminating openstack virtual machines.
 """
-from keystoneauth1 import session
-from keystoneauth1 import loading
-import novaclient.exceptions
-from novaclient import client as nvclient
-from time import sleep
+import shade
 import logging
 import uuid
 
-WAIT_BEFORE_ATTACHING_IP = 5
 
-
-class NovaClient(object):
+class CloudClient(object):
     """
-    Wraps up openstack nova operations.
+    Wraps up openstack shade operations.
     """
     def __init__(self, credentials):
         """
-        Setup internal nova client based on credentials in cloud_settings
+        Setup internal client based on credentials in cloud_settings
         :credentials: dictionary of url, username, password, etc
         """
-        nova_session = NovaClient.get_session(credentials)
-        self.nova = nvclient.Client('2', session=nova_session)
-
-    @staticmethod
-    def get_session(credentials):
-        """
-        Returns a session from openstack credentials. Used by nova client
-        :credentials: dictionary of url, username, password, etc
-        :return: session.Session for the specified credentials
-        """
-        loader = loading.get_plugin_loader('password')
-        auth = loader.load_from_options(**credentials)
-        sess = session.Session(auth=auth)
-        return sess
+        self.cloud = shade.openstack_cloud(project_name=credentials['project_name'],
+            username=credentials['username'],
+            user_domain_name=credentials['user_domain_name'],
+            auth_url=credentials['auth_url'],
+            password=credentials['password'],
+            project_domain_name=credentials['project_domain_name'])
 
     def launch_instance(self, vm_settings, server_name, flavor_name, script_contents):
         """
@@ -45,40 +31,19 @@ class NovaClient(object):
         :param script_contents: str: contents of a bash script that will be run on startup
         :return: openstack instance created
         """
-        image = self.nova.images.find(name=vm_settings.worker_image_name)
         vm_flavor_name = flavor_name
         if not vm_flavor_name:
             vm_flavor_name = vm_settings.default_favor_name
-        flavor = self.nova.flavors.find(name=vm_flavor_name)
-        net = self.nova.networks.find(label=vm_settings.network_name)
-        nics = [{'net-id': net.id}]
-        instance = self.nova.servers.create(name=server_name, image=image, flavor=flavor,
-                                            key_name=vm_settings.ssh_key_name,
-                                            nics=nics, userdata=script_contents)
+        instance = self.cloud.create_server(
+            name=server_name,
+            image=vm_settings.worker_image_name,
+            flavor=vm_flavor_name,
+            key_name=vm_settings.ssh_key_name,
+            network=vm_settings.network_name,
+            auto_ip=vm_settings.allocate_floating_ips,
+            ip_pool=vm_settings.floating_ip_pool_name,
+            userdata=script_contents)
         return instance
-
-    def attach_floating_ip(self, instance, floating_ip_pool_name):
-        """
-        Attach a floating IP address to an openstack VM.
-        :param instance: openstack VM
-        :param floating_ip_pool_name: str: name of the pool of ip addresses
-        :return: str: ip address that was assigned
-        """
-        floating_ip = self.nova.floating_ips.create(floating_ip_pool_name)
-        instance.add_floating_ip(floating_ip)
-        return floating_ip.ip
-
-    def _delete_floating_ip(self, instance):
-        """
-        Delete floating ip address associated with the instance with server_name.
-        If not found will log as as warning.
-        :param instance: Server: VM we want to delete a floating IP from
-        """
-        try:
-            floating_ip = self.nova.floating_ips.find(instance_id=instance.id)
-            floating_ip.delete()
-        except novaclient.exceptions.NotFound:
-            logging.warn('No floating ip address found for {} ({})'.format(instance.name, instance.id))
 
     def terminate_instance(self, server_name, delete_floating_ip):
         """
@@ -86,10 +51,7 @@ class NovaClient(object):
         :param server_name: str: name of the VM to terminate
         :param delete_floating_ip: bool: should we try to delete an attached floating ip address
         """
-        instance = self.nova.servers.find(name=server_name)
-        if delete_floating_ip:
-            self._delete_floating_ip(instance)
-        self.nova.servers.delete(instance)
+        self.cloud.delete_server(server_name, delete_ips=delete_floating_ip)
 
 
 class CloudService(object):
@@ -103,7 +65,7 @@ class CloudService(object):
         :param project_name: name of the project(tenant) which will contain our VMs
         """
         self.config = config
-        self.nova_client = NovaClient(config.cloud_settings.credentials(project_name))
+        self.cloud_client = CloudClient(config.cloud_settings.credentials(project_name))
 
     def launch_instance(self, server_name, flavor_name, script_contents):
         """
@@ -114,15 +76,8 @@ class CloudService(object):
         :return: instance, ip address: openstack instance object and the floating ip address assigned
         """
         vm_settings = self.config.vm_settings
-        instance = self.nova_client.launch_instance(vm_settings, server_name, flavor_name, script_contents)
-        ip_address = None
-        if vm_settings.allocate_floating_ips:
-            sleep(WAIT_BEFORE_ATTACHING_IP)
-            ip_address = self.nova_client.attach_floating_ip(instance, vm_settings.floating_ip_pool_name)
-            logging.info('launched {} on floating ip {}'.format(server_name, ip_address))
-        else:
-            logging.info('launched {} with id'.format(server_name, instance.id))
-        return instance, ip_address
+        instance = self.cloud_client.launch_instance(vm_settings, server_name, flavor_name, script_contents)
+        return instance, instance.accessIPv4
 
     def terminate_instance(self, server_name):
         """
@@ -131,7 +86,7 @@ class CloudService(object):
         """
         vm_settings = self.config.vm_settings
         logging.info('terminating instance {}'.format(server_name))
-        self.nova_client.terminate_instance(server_name, delete_floating_ip=vm_settings.allocate_floating_ips)
+        self.cloud_client.terminate_instance(server_name, delete_floating_ip=vm_settings.allocate_floating_ips)
 
     def make_vm_name(self, job_id):
         """

--- a/lando/server/cloudservice.py
+++ b/lando/server/cloudservice.py
@@ -15,12 +15,7 @@ class CloudClient(object):
         Setup internal client based on credentials in cloud_settings
         :credentials: dictionary of url, username, password, etc
         """
-        self.cloud = shade.openstack_cloud(project_name=credentials['project_name'],
-            username=credentials['username'],
-            user_domain_name=credentials['user_domain_name'],
-            auth_url=credentials['auth_url'],
-            password=credentials['password'],
-            project_domain_name=credentials['project_domain_name'])
+        self.cloud = shade.openstack_cloud(**credentials)
 
     def launch_instance(self, vm_settings, server_name, flavor_name, script_contents):
         """

--- a/lando/server/tests/test_cloudservice.py
+++ b/lando/server/tests/test_cloudservice.py
@@ -1,54 +1,47 @@
 from __future__ import absolute_import
 from unittest import TestCase
-import novaclient.exceptions
 from lando.server.cloudservice import CloudService
 import mock
 
 
 class TestCwlWorkflow(TestCase):
-    @mock.patch('lando.server.cloudservice.sleep')
-    @mock.patch('keystoneauth1.loading.get_plugin_loader')
-    @mock.patch('keystoneauth1.session.Session')
-    @mock.patch('novaclient.client.Client')
-    def test_that_flavor_overrides_default(self, mock_client, mock_session, mock_get_plugin_loader, mock_sleep):
+    @mock.patch('lando.server.cloudservice.shade')
+    def test_that_flavor_overrides_default(self, mock_shade):
         config = mock.MagicMock()
         config.vm_settings.default_favor_name = 'm1.xbig'
         cloud_service = CloudService(config, project_name='bespin_user1')
         cloud_service.launch_instance(server_name="worker1", flavor_name='m1.GIANT', script_contents="")
-        find_flavor_method = mock_client().flavors.find
-        find_flavor_method.assert_called_with(name='m1.GIANT')
+        mock_shade.openstack_cloud()
+        mock_shade.openstack_cloud().create_server.assert_called()
+        args, kw_args = mock_shade.openstack_cloud().create_server.call_args
+        self.assertEqual(kw_args['flavor'], 'm1.GIANT')
 
-    @mock.patch('lando.server.cloudservice.sleep')
-    @mock.patch('keystoneauth1.loading.get_plugin_loader')
-    @mock.patch('keystoneauth1.session.Session')
-    @mock.patch('novaclient.client.Client')
-    def test_that_no_flavor_chooses_default(self, mock_client, mock_session, mock_get_plugin_loader, mock_sleep):
+    @mock.patch('lando.server.cloudservice.shade')
+    def test_that_no_flavor_chooses_default(self, mock_shade):
         config = mock.MagicMock()
         config.vm_settings.default_favor_name = 'm1.xbig'
         cloud_service = CloudService(config, project_name='bespin_user1')
         cloud_service.launch_instance(server_name="worker1", flavor_name=None, script_contents="")
-        find_flavor_method = mock_client().flavors.find
-        find_flavor_method.assert_called_with(name='m1.xbig')
+        mock_shade.openstack_cloud().create_server.assert_called()
+        args, kw_args = mock_shade.openstack_cloud().create_server.call_args
+        self.assertEqual(kw_args['flavor'], 'm1.xbig')
 
-    @mock.patch('lando.server.cloudservice.sleep')
-    @mock.patch('keystoneauth1.loading.get_plugin_loader')
-    @mock.patch('keystoneauth1.session.Session')
-    @mock.patch('novaclient.client.Client')
-    def test_launch_instance_no_floating_ip(self, mock_client, mock_session, mock_get_plugin_loader, mock_sleep):
-        config = mock.MagicMock()
+    @mock.patch('lando.server.cloudservice.shade')
+    def test_launch_instance_no_floating_ip(self, mock_shade):
+        mock_shade.openstack_cloud().create_server.return_value = mock.Mock(accessIPv4='')
+        config = mock.MagicMock(vm_settings=mock.Mock(worker_image_name='myvm', floating_ip_pool_name='somepool'))
         config.vm_settings.allocate_floating_ips = False
         config.vm_settings.default_favor_name = 'm1.large'
         cloud_service = CloudService(config, project_name='bespin_user1')
         instance, ip_address = cloud_service.launch_instance(server_name="worker1", flavor_name=None, script_contents="")
-        self.assertEqual(None, ip_address)
-        mock_client().servers.create.assert_called()
-        mock_client().floating_ips.create.assert_not_called()
+        self.assertEqual('', ip_address)
+        mock_shade.openstack_cloud().create_server.assert_called()
+        args, kw_args = mock_shade.openstack_cloud().create_server.call_args
+        self.assertEqual(kw_args['auto_ip'], False)
 
-    @mock.patch('lando.server.cloudservice.sleep')
-    @mock.patch('keystoneauth1.loading.get_plugin_loader')
-    @mock.patch('keystoneauth1.session.Session')
-    @mock.patch('novaclient.client.Client')
-    def test_launch_instance_with_floating_ip(self, mock_client, mock_session, mock_get_plugin_loader, mock_sleep):
+    @mock.patch('lando.server.cloudservice.shade')
+    def test_launch_instance_with_floating_ip(self, mock_shade):
+        mock_shade.openstack_cloud().create_server.return_value = mock.Mock(accessIPv4='123')
         config = mock.MagicMock()
         config.vm_settings.allocate_floating_ips = True
         config.vm_settings.default_favor_name = 'm1.large'
@@ -56,43 +49,27 @@ class TestCwlWorkflow(TestCase):
         instance, ip_address = cloud_service.launch_instance(server_name="worker1", flavor_name=None,
                                                              script_contents="")
         self.assertNotEqual(None, ip_address)
-        mock_client().servers.create.assert_called()
-        mock_client().floating_ips.create.assert_called()
+        mock_shade.openstack_cloud().create_server.assert_called()
+        args, kw_args = mock_shade.openstack_cloud().create_server.call_args
+        self.assertEqual(kw_args['auto_ip'], True)
 
-    @mock.patch('keystoneauth1.loading.get_plugin_loader')
-    @mock.patch('keystoneauth1.session.Session')
-    @mock.patch('novaclient.client.Client')
-    def test_terminate_instance_no_floating_ip(self, mock_client, mock_session, mock_get_plugin_loader):
+    @mock.patch('lando.server.cloudservice.shade')
+    def test_terminate_instance_no_floating_ip(self, mock_shade):
         config = mock.MagicMock()
         config.vm_settings.allocate_floating_ips = False
         config.vm_settings.default_favor_name = 'm1.large'
         cloud_service = CloudService(config, project_name='bespin_user1')
         cloud_service.terminate_instance(server_name='worker1')
-        mock_client().servers.delete.assert_called()
-        mock_client().floating_ips.find.assert_not_called()
+        mock_shade.openstack_cloud().delete_server.assert_called()
+        args, kw_args = mock_shade.openstack_cloud().delete_server.call_args
+        self.assertEqual(kw_args['delete_ips'], False)
 
-    @mock.patch('keystoneauth1.loading.get_plugin_loader')
-    @mock.patch('keystoneauth1.session.Session')
-    @mock.patch('novaclient.client.Client')
-    def test_terminate_instance_with_floating_ip(self, mock_client, mock_session, mock_get_plugin_loader):
+    @mock.patch('lando.server.cloudservice.shade')
+    def test_terminate_instance_with_floating_ip(self, mock_shade):
         config = mock.MagicMock()
         config.vm_settings.allocate_floating_ips = True
         config.vm_settings.default_favor_name = 'm1.large'
         cloud_service = CloudService(config, project_name='bespin_user1')
         cloud_service.terminate_instance(server_name='worker1')
-        mock_client().servers.delete.assert_called()
-        mock_client().floating_ips.find.assert_called()
-        mock_client().floating_ips.find().delete.assert_called()
-
-    @mock.patch('keystoneauth1.loading.get_plugin_loader')
-    @mock.patch('keystoneauth1.session.Session')
-    @mock.patch('novaclient.client.Client')
-    def test_terminate_instance_with_missing_floating_ip(self, mock_client, mock_session, mock_get_plugin_loader):
-        mock_client().floating_ips.find.side_effect = novaclient.exceptions.NotFound(404)
-        config = mock.MagicMock()
-        config.vm_settings.allocate_floating_ips = True
-        config.vm_settings.default_favor_name = 'm1.large'
-        cloud_service = CloudService(config, project_name='bespin_user1')
-        cloud_service.terminate_instance(server_name='worker1')
-        mock_client().servers.delete.assert_called()
-        mock_client().floating_ips.find.assert_called()
+        args, kw_args = mock_shade.openstack_cloud().delete_server.call_args
+        self.assertEqual(kw_args['delete_ips'], True)

--- a/lando/server/tests/test_lando.py
+++ b/lando/server/tests/test_lando.py
@@ -8,7 +8,7 @@ import json
 from lando.server.lando import Lando
 from lando.server.jobapi import JobStates, JobSteps
 from mock import MagicMock, patch
-from novaclient.exceptions import NotFound
+from shade import OpenStackCloudException
 
 
 LANDO_CONFIG = """
@@ -419,7 +419,7 @@ Send progress notification. Job:1 State:F Step:None
     def test_create_failing_vm(self, mock_requests, MockLandoWorkerClient, MockJobSettings):
         job_id = 1
         mock_settings, report = make_mock_settings_and_report(job_id)
-        report.launch_instance_error = NotFound('some vm image')
+        report.launch_instance_error = OpenStackCloudException('some vm image')
         MockJobSettings.return_value = mock_settings
         lando = Lando(MagicMock())
         lando.start_job(MagicMock(job_id=job_id))

--- a/lando/worker/tests/test_cwlworkflow.py
+++ b/lando/worker/tests/test_cwlworkflow.py
@@ -11,6 +11,7 @@ from lando.exceptions import JobStepFailed
 
 SAMPLE_WORKFLOW = """
 {
+    "cwlVersion": "v1.0",
     "class": "CommandLineTool",
     "baseCommand": "cat",
     "stdout": "$(inputs.outputfile)",

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from setuptools import setup, find_packages
 
 
 LANDO_REQUIREMENTS = [
+      "Babel==2.3.4",
+      "shade==1.20.0",
       "cwlref-runner==1.0",
       "DukeDSClient",
       "humanfriendly==2.4",
       "Jinja2==2.9.5",
-      "keystoneauth1>=2.11.0",
       "lando-messaging",
       "python-dateutil==2.6.0",
-      "python-novaclient>=2.21.0,!=2.27.0,!=2.32.0",
       "PyYAML==3.11",
       "requests==2.10.0",
 ]


### PR DESCRIPTION
Nova keeps changing the API and shade is much simpler for controlling openstack.
shade handles allocating floating IPs internally so we no longer need to manually do that.
Reworks the setup.py requirements (needed specific Babel version for install to work).
Fixed cwl test that broke with cwl-runner changes.

Fixes #25 