### PR TITLE
Send worker bespin admin credentials

### DIFF
--- a/lando/server/jobapi.py
+++ b/lando/server/jobapi.py
@@ -74,13 +74,13 @@ class BespinApi(object):
     def _make_url(self, suffix):
         return '{}/admin/{}'.format(self.settings.url, suffix)
 
-    def get_dds_user_credentials(self, user_id):
+    def get_dds_user_credentials(self):
         """
         Get the duke data service user credentials for a user id.
         :param user_id: int: bespin user id
         :return: dict: credentials details
         """
-        path = 'dds-user-credentials/?user={}'.format(user_id)
+        path = 'dds-user-credentials/'
         url = self._make_url(path)
         return self._get_results(url)
 
@@ -181,14 +181,13 @@ class JobApi(object):
 
     def get_credentials(self):
         """
-        Get all dds user/app credentials attached to this job.
-        :return: Credentials: let's user lookup credential info based on bespin user/app ids.
+        Get all bespin service account credentials.
+        :return: Credentials: bespin DukeDS credentials
         """
         job = self.get_job()
-        user_id = job.user_id
         credentials = Credentials()
 
-        for user_credential_data in self.api.get_dds_user_credentials(user_id):
+        for user_credential_data in self.api.get_dds_user_credentials():
             credentials.add_user_credential(DDSUserCredential(user_credential_data))
 
         return credentials

--- a/lando/server/jobapi.py
+++ b/lando/server/jobapi.py
@@ -76,8 +76,7 @@ class BespinApi(object):
 
     def get_dds_user_credentials(self):
         """
-        Get the duke data service user credentials for a user id.
-        :param user_id: int: bespin user id
+        Get all duke data service user credentials.
         :return: dict: credentials details
         """
         path = 'dds-user-credentials/'

--- a/lando/server/tests/test_jobapi.py
+++ b/lando/server/tests/test_jobapi.py
@@ -146,6 +146,9 @@ class TestJobApi(TestCase):
 
     @patch('lando.server.jobapi.requests')
     def test_get_credentials(self, mock_requests):
+        """
+        The only stored credentials are the bespin system credentials.
+        """
         job_response_payload = {
             'id': 4,
             'user_id': 23,
@@ -171,7 +174,7 @@ class TestJobApi(TestCase):
         user_credentials_response = [
             {
                 'id': 5,
-                'user': 23,
+                'user': 1,
                 'token': '1239109',
                 'endpoint': {
                     'id': 3,
@@ -188,7 +191,7 @@ class TestJobApi(TestCase):
 
         user_credentials = job_api.get_credentials()
         args, kwargs = mock_requests.get.call_args
-        self.assertEqual(args[0], 'APIURL/admin/dds-user-credentials/?user=23')
+        self.assertEqual(args[0], 'APIURL/admin/dds-user-credentials/')
 
         user_cred = user_credentials.dds_user_credentials[5]
         self.assertEqual('1239109', user_cred.token)


### PR DESCRIPTION
We were still sending the credentials associated with the user who
was running the job. Now that the users use OAuth/DDS credentials
to give the bespin user credentials download permission we need
to send the bespin user credentials.
Fixes #27