### PR TITLE
Give project to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ Assumes you have installed Python 2.7, [Openstack](https://www.openstack.org/), 
 
 ### Install lando-messaging and lando.
 ```
-pip install git+git://github.com/Duke-GCB/lando-messaging.git 
 pip install git+git://github.com/Duke-GCB/lando.git
 ```
 

--- a/lando/server/jobapi.py
+++ b/lando/server/jobapi.py
@@ -235,7 +235,8 @@ class Job(object):
         :param data: dict: job values returned from bespin.
         """
         self.id = data['id']
-        self.user_id = data['user_id']
+        self.user_id = data['user']['id']
+        self.username = data['user']['username']
         self.created = data['created']
         self.name = data['name']
         self.state = data['state']

--- a/lando/server/tests/test_jobapi.py
+++ b/lando/server/tests/test_jobapi.py
@@ -19,7 +19,10 @@ class TestJobApi(TestCase):
         job_api = self.setup_job_api(1)
         job_response_payload = {
             'id': 1,
-            'user_id': 23,
+            'user': {
+                'id': 23,
+                'username': 'joe@joe.com'
+            },
             'state': 'N',
             'step': '',
             'name': 'myjob',
@@ -48,6 +51,7 @@ class TestJobApi(TestCase):
 
         self.assertEqual(1, job.id)
         self.assertEqual(23, job.user_id)
+        self.assertEqual('joe@joe.com', job.username)
         self.assertEqual('N', job.state)
         self.assertEqual('m1.tiny', job.vm_flavor)
         self.assertEqual('', job.vm_instance_name)
@@ -151,7 +155,10 @@ class TestJobApi(TestCase):
         """
         job_response_payload = {
             'id': 4,
-            'user_id': 23,
+            'user': {
+                'id': 1,
+                'username': 'joe@joe.com'
+            },
             'state': 'N',
             'step': '',
             'vm_flavor': 'm1.tiny',
@@ -204,7 +211,10 @@ class TestJobApi(TestCase):
         jobs_response = [
             {
                 'id': 1,
-                'user_id': 23,
+                'user': {
+                    'id': 1,
+                    'username': 'joe@joe.com'
+                },
                 'state': 'N',
                 'step': '',
                 'name': 'SomeJob',

--- a/lando/worker/tests/test_staging.py
+++ b/lando/worker/tests/test_staging.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+from unittest import TestCase
+from lando.worker.staging import SaveJobOutput
+from mock import patch, Mock, MagicMock
+
+
+class TestSaveJobOutput(TestCase):
+    def setUp(self):
+        payload = MagicMock()
+        payload.job_details.workflow.name = 'SomeWorkflow'
+        payload.job_details.workflow.version = 2
+        payload.job_details.name = 'MyJob'
+        payload.job_details.created = '2017-03-21T13:29:09.123603Z'
+        payload.job_details.username = 'john@john.org'
+        self.payload = payload
+
+    def test_create_project_name(self):
+        name = SaveJobOutput.create_project_name(self.payload)
+        self.assertEqual("Bespin SomeWorkflow v2 MyJob 2017-29-21", name)
+
+    def test_get_dukeds_username(self):
+        self.payload.job_details.username = 'joe@joe.com'
+        save_job_output=SaveJobOutput(self.payload)
+        self.assertEqual('joe', save_job_output.get_dukeds_username())
+        self.payload.job_details.username = 'bob123'
+        save_job_output=SaveJobOutput(self.payload)
+        self.assertEqual('bob123', save_job_output.get_dukeds_username())
+
+    @patch('lando.worker.staging.ProjectUpload')
+    @patch('lando.worker.staging.RemoteStore')
+    def test_run(self, mock_remote_store, mock_project_upload):
+        mock_project_upload().local_project = Mock(remote_id='1234')
+        mock_remote_store().lookup_user_by_username.return_value = Mock(id='4567')
+        self.payload.job_details.username = 'joe123@something.org'
+
+        save_job_output = SaveJobOutput(self.payload)
+        save_job_output.run(['/tmp/jobresults'])
+
+        # We should upload the resulting directory into a new project
+        mock_project_upload().run.assert_called()
+
+        # We should give permissions to the user
+        lookup_user_func = mock_remote_store().lookup_user_by_username
+        lookup_user_func.assert_called_with('joe123')
+        set_project_permission_func = mock_remote_store().data_service.set_user_project_permission
+        set_project_permission_func.assert_called_with('1234',
+                                                       '4567', 'project_admin')

--- a/lando/worker/worker.py
+++ b/lando/worker/worker.py
@@ -49,6 +49,10 @@ class LandoWorkerSettings(object):
     def make_upload_project(project_name, file_folder_list):
         return staging.UploadProject(project_name, file_folder_list)
 
+    @staticmethod
+    def make_save_job_output(payload):
+        return staging.SaveJobOutput(payload)
+
 
 class LandoWorkerActions(object):
     """
@@ -100,7 +104,7 @@ class LandoWorkerActions(object):
         """
         source_directory = os.path.join(working_directory, cwlworkflow.CWL_WORKING_DIRECTORY)
         upload_paths = [os.path.join(source_directory, path) for path in os.listdir(source_directory)]
-        save_job_output = staging.SaveJobOutput(payload)
+        save_job_output = self.settings.make_save_job_output(payload)
         project = save_job_output.run(upload_paths)
         self.client.job_step_store_output_complete(payload, project.remote_id)
 

--- a/lando/worker/worker.py
+++ b/lando/worker/worker.py
@@ -98,24 +98,11 @@ class LandoWorkerActions(object):
         :param working_directory: str: path to working directory that contains the output directory
         :param payload: path to directory containing files we will run the workflow using
         """
-        project_name = self.create_project_name(payload)
-        staging_context = self.settings.make_staging_context(payload.credentials)
         source_directory = os.path.join(working_directory, cwlworkflow.CWL_WORKING_DIRECTORY)
         upload_paths = [os.path.join(source_directory, path) for path in os.listdir(source_directory)]
-        upload_project = self.settings.make_upload_project(project_name, upload_paths)
-        config = staging_context.get_duke_ds_config(payload.job_details.output_project.dds_user_credentials)
-        project = upload_project.run(config)
+        save_job_output = staging.SaveJobOutput(payload)
+        project = save_job_output.run(upload_paths)
         self.client.job_step_store_output_complete(payload, project.remote_id)
-
-    @staticmethod
-    def create_project_name(payload):
-        job_details = payload.job_details
-        job_name = job_details.name
-        job_created = dateutil.parser.parse(job_details.created).strftime("%Y-%M-%d")
-        workflow = job_details.workflow
-        workflow_name = workflow.name
-        workflow_version = workflow.version
-        return "Bespin {} v{} {} {}".format(workflow_name, workflow_version, job_name, job_created)
 
 
 class LandoWorker(object):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(name='lando',
       license='MIT',
       packages=find_packages(),
       install_requires=LANDO_REQUIREMENTS,
-      dependency_links=['https://github.com/Duke-GCB/lando-messaging/tarball/master#egg=lando-messaging'],
       zip_safe=False,
       entry_points={
             'console_scripts': [


### PR DESCRIPTION
Changes to transfer project to requesting user after we finish uploading.
Requires changes to (bespin-api)[https://github.com/Duke-GCB/bespin-api] adding username to the AdminJobSerializer.