### PR TITLE
Fix project name to contain year-month-day

### DIFF
--- a/lando/worker/staging.py
+++ b/lando/worker/staging.py
@@ -216,7 +216,7 @@ class SaveJobOutput(object):
         """
         job_details = payload.job_details
         job_name = job_details.name
-        job_created = dateutil.parser.parse(job_details.created).strftime("%Y-%M-%d")
+        job_created = dateutil.parser.parse(job_details.created).strftime("%Y-%m-%d")
         workflow = job_details.workflow
         workflow_name = workflow.name
         workflow_version = workflow.version

--- a/lando/worker/tests/test_staging.py
+++ b/lando/worker/tests/test_staging.py
@@ -16,7 +16,7 @@ class TestSaveJobOutput(TestCase):
 
     def test_create_project_name(self):
         name = SaveJobOutput.create_project_name(self.payload)
-        self.assertEqual("Bespin SomeWorkflow v2 MyJob 2017-29-21", name)
+        self.assertEqual("Bespin SomeWorkflow v2 MyJob 2017-03-21", name)
 
     def test_get_dukeds_username(self):
         self.payload.job_details.username = 'joe@joe.com'


### PR DESCRIPTION
Big "M" is the minute. 
Little "m" is the month.
Somehow had this wrong in the test too.