### PR TITLE
Fix so cwlref-runner will install successfully

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ from setuptools import setup, find_packages
 
 
 LANDO_REQUIREMENTS = [
+      "ruamel.yaml==0.15.2",
       "Babel==2.3.4",
       "shade==1.20.0",
       "cwlref-runner==1.0",


### PR DESCRIPTION
Fixes #38 
Once https://github.com/common-workflow-language/cwltool/pull/450 is added to a release we can remove this change.