### PR TITLE
Changes to use cwltoil to run workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The queue name `local_worker` is always used for workers when `fake_cloud_servic
 If you are running on osx you may need to specify custom `--tmpdir-prefix` and `--tmp-outdir-prefix` flags for cwl.
 You can replace the default `cwl-runner` command by adding lines similar to these:
 ```
-workflow_base_command:
+cwl_base_command:
   - "cwl-runner"
   - "--debug"
   - "--tmpdir-prefix=/Users/jpb67/Documents/work/tmp"

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The queue name `local_worker` is always used for workers when `fake_cloud_servic
 If you are running on osx you may need to specify custom `--tmpdir-prefix` and `--tmp-outdir-prefix` flags for cwl.
 You can replace the default `cwl-runner` command by adding lines similar to these:
 ```
-cwl_base_command:
+workflow_base_command:
   - "cwl-runner"
   - "--debug"
   - "--tmpdir-prefix=/Users/jpb67/Documents/work/tmp"

--- a/lando/server/config.py
+++ b/lando/server/config.py
@@ -42,7 +42,7 @@ class ServerConfig(object):
         """
         work_queue = self.work_queue_config
         data = {
-            'workflow_base_command': self.vm_settings.workflow_base_command,
+            'cwl_base_command': self.vm_settings.cwl_base_command,
             'host': work_queue.host,
             'username': work_queue.worker_username,
             'password': work_queue.worker_password,
@@ -75,7 +75,7 @@ class VMSettings(object):
         self.allocate_floating_ips = data.get('allocate_floating_ips', False)
         self.floating_ip_pool_name = get_or_raise_config_exception(data, 'floating_ip_pool_name')
         self.default_favor_name = get_or_raise_config_exception(data, 'default_favor_name')
-        self.workflow_base_command = data.get("workflow_base_command")
+        self.cwl_base_command = data.get("cwl_base_command")
 
 
 class CloudSettings(object):

--- a/lando/server/config.py
+++ b/lando/server/config.py
@@ -42,6 +42,7 @@ class ServerConfig(object):
         """
         work_queue = self.work_queue_config
         data = {
+            'workflow_base_command': self.vm_settings.workflow_base_command,
             'host': work_queue.host,
             'username': work_queue.worker_username,
             'password': work_queue.worker_password,
@@ -74,6 +75,7 @@ class VMSettings(object):
         self.allocate_floating_ips = data.get('allocate_floating_ips', False)
         self.floating_ip_pool_name = get_or_raise_config_exception(data, 'floating_ip_pool_name')
         self.default_favor_name = get_or_raise_config_exception(data, 'default_favor_name')
+        self.workflow_base_command = data.get("workflow_base_command")
 
 
 class CloudSettings(object):

--- a/lando/server/tests/test_config.py
+++ b/lando/server/tests/test_config.py
@@ -49,6 +49,7 @@ class TestServerConfig(TestCase):
         self.assertEqual('jpb67', config.vm_settings.ssh_key_name)
         #  by default allocate_floating_ips is off
         self.assertEqual(False, config.vm_settings.allocate_floating_ips)
+        self.assertEqual(None, config.vm_settings.cwl_base_command)
 
         self.assertEqual("http://10.109.252.9:5000/v3", config.cloud_settings.auth_url)
         self.assertEqual("jpb67", config.cloud_settings.username)
@@ -119,3 +120,4 @@ username: lobot
 """
         result = config.make_worker_config_yml('worker_1')
         self.assertMultiLineEqual(expected.strip(), result.strip())
+        self.assertEqual(['cwltoil', '--not-strict'], config.vm_settings.cwl_base_command)

--- a/lando/server/tests/test_config.py
+++ b/lando/server/tests/test_config.py
@@ -98,6 +98,24 @@ host: 10.109.253.74
 password: tobol
 queue_name: worker_1
 username: lobot
+workflow_base_command: null
+"""
+        result = config.make_worker_config_yml('worker_1')
+        self.assertMultiLineEqual(expected.strip(), result.strip())
+
+    def test_make_worker_config_yml_custom_workflow_base_command(self):
+        line = '  workflow_base_command:\n  - "cwltoil"\n  - "--not-strict"'
+        filename = write_temp_return_filename(GOOD_CONFIG.format(line))
+        config = ServerConfig(filename)
+        os.unlink(filename)
+        expected = """
+host: 10.109.253.74
+password: tobol
+queue_name: worker_1
+username: lobot
+workflow_base_command:
+- cwltoil
+- --not-strict
 """
         result = config.make_worker_config_yml('worker_1')
         self.assertMultiLineEqual(expected.strip(), result.strip())

--- a/lando/server/tests/test_config.py
+++ b/lando/server/tests/test_config.py
@@ -94,28 +94,28 @@ class TestServerConfig(TestCase):
         config = ServerConfig(filename)
         os.unlink(filename)
         expected = """
+cwl_base_command: null
 host: 10.109.253.74
 password: tobol
 queue_name: worker_1
 username: lobot
-workflow_base_command: null
 """
         result = config.make_worker_config_yml('worker_1')
         self.assertMultiLineEqual(expected.strip(), result.strip())
 
-    def test_make_worker_config_yml_custom_workflow_base_command(self):
-        line = '  workflow_base_command:\n  - "cwltoil"\n  - "--not-strict"'
+    def test_make_worker_config_yml_custom_cwl_base_command(self):
+        line = '  cwl_base_command:\n  - "cwltoil"\n  - "--not-strict"'
         filename = write_temp_return_filename(GOOD_CONFIG.format(line))
         config = ServerConfig(filename)
         os.unlink(filename)
         expected = """
+cwl_base_command:
+- cwltoil
+- --not-strict
 host: 10.109.253.74
 password: tobol
 queue_name: worker_1
 username: lobot
-workflow_base_command:
-- cwltoil
-- --not-strict
 """
         result = config.make_worker_config_yml('worker_1')
         self.assertMultiLineEqual(expected.strip(), result.strip())

--- a/lando/worker/config.py
+++ b/lando/worker/config.py
@@ -21,7 +21,8 @@ class WorkerConfig(object):
             if not data:
                 raise InvalidConfigException("Empty config file {}.".format(self.filename))
             self.work_queue_config = WorkQueue(data)
-            self.cwl_base_command = data.get('cwl_base_command', None)
+            self.workflow_base_command = data.get('workflow_base_command', None)
+
 
 class WorkQueue(object):
     """

--- a/lando/worker/config.py
+++ b/lando/worker/config.py
@@ -21,7 +21,7 @@ class WorkerConfig(object):
             if not data:
                 raise InvalidConfigException("Empty config file {}.".format(self.filename))
             self.work_queue_config = WorkQueue(data)
-            self.workflow_base_command = data.get('workflow_base_command', None)
+            self.cwl_base_command = data.get('cwl_base_command', None)
 
 
 class WorkQueue(object):

--- a/lando/worker/cwlworkflow.py
+++ b/lando/worker/cwlworkflow.py
@@ -161,7 +161,9 @@ class CwlWorkflowProcess(object):
         if not base_command:
             base_command = [RUN_CWL_COMMAND]
         self.command = base_command[:]
-        self.command.extend([RUN_CWL_OUTDIR_ARG, local_output_directory, workflow_file, job_order_filename])
+        # cwltoil requires an absolute path for output directory
+        absolute_output_directory = os.path.abspath(local_output_directory)
+        self.command.extend([RUN_CWL_OUTDIR_ARG, absolute_output_directory, workflow_file, job_order_filename])
 
     def run(self):
         """

--- a/lando/worker/cwlworkflow.py
+++ b/lando/worker/cwlworkflow.py
@@ -108,16 +108,16 @@ class CwlWorkflow(object):
     3. Gathers stderr/stdout output from the process
     4. If exit status is not 0 raises JobStepFailed including output
     """
-    def __init__(self, job_id, working_directory, workflow_base_command):
+    def __init__(self, job_id, working_directory, cwl_base_command):
         """
         Setup workflow
         :param job_id: int: job id we are running a workflow for
         :param working_directory: str: path to working directory that contains input files
-        :param workflow_base_command: [str] or None: array of cwl command and arguments (osx requires special arguments)
+        :param cwl_base_command: [str] or None: array of cwl command and arguments (osx requires special arguments)
         """
         self.job_id = job_id
         self.working_directory = working_directory
-        self.workflow_base_command = workflow_base_command
+        self.cwl_base_command = cwl_base_command
 
     def run(self, cwl_file_url, workflow_object_name, job_order):
         """
@@ -131,7 +131,7 @@ class CwlWorkflow(object):
         workflow_file = cwl_directory.workflow_path
         if workflow_object_name:
             workflow_file += workflow_object_name
-        process = CwlWorkflowProcess(self.workflow_base_command,
+        process = CwlWorkflowProcess(self.cwl_base_command,
                                      cwl_directory.output_directory,
                                      workflow_file,
                                      cwl_directory.job_order_file_path)
@@ -144,10 +144,10 @@ class CwlWorkflow(object):
 
 
 class CwlWorkflowProcess(object):
-    def __init__(self, workflow_base_command, local_output_directory, workflow_file, job_order_filename):
+    def __init__(self, cwl_base_command, local_output_directory, workflow_file, job_order_filename):
         """
         Setup to run cwl workflow using the supplied parameters.
-        :param workflow_base_command:  [str] or None: array of cwl command and arguments (osx requires special arguments)
+        :param cwl_base_command:  [str] or None: array of cwl command and arguments (osx requires special arguments)
         :param local_output_directory: str: path to directory we will save output files into
         :param workflow_file: str: path to the cwl workflow
         :param job_order_filename: str: path to the cwl job order (input file)
@@ -157,7 +157,7 @@ class CwlWorkflowProcess(object):
         self.return_code = None
         self.started = None
         self.finished = None
-        base_command = workflow_base_command
+        base_command = cwl_base_command
         if not base_command:
             base_command = [RUN_CWL_COMMAND]
         self.command = base_command[:]

--- a/lando/worker/cwlworkflow.py
+++ b/lando/worker/cwlworkflow.py
@@ -162,14 +162,17 @@ class CwlWorkflowProcess(object):
             base_command = [RUN_CWL_COMMAND]
         self.command = base_command[:]
         # cwltoil requires an absolute path for output directory
-        absolute_output_directory = os.path.abspath(local_output_directory)
-        self.command.extend([RUN_CWL_OUTDIR_ARG, absolute_output_directory, workflow_file, job_order_filename])
+        self.absolute_output_directory = os.path.abspath(local_output_directory)
+        self.command.extend([RUN_CWL_OUTDIR_ARG, self.absolute_output_directory, workflow_file, job_order_filename])
 
     def run(self):
         """
         Run job saving results in process_output, process_error_output, and return_code members.
         :param command: [str]: array of strings representing a workflow command and its arguments
         """
+        # Create output directory for cwltoil
+        if not os.path.exists(self.absolute_output_directory):
+            os.mkdir(self.absolute_output_directory)
         self.started = datetime.datetime.now()
         p = Popen(self.command, stdin=PIPE, stderr=PIPE, stdout=PIPE, bufsize=1)
         self.output = ""

--- a/lando/worker/cwlworkflow.py
+++ b/lando/worker/cwlworkflow.py
@@ -108,16 +108,16 @@ class CwlWorkflow(object):
     3. Gathers stderr/stdout output from the process
     4. If exit status is not 0 raises JobStepFailed including output
     """
-    def __init__(self, job_id, working_directory, cwl_base_command):
+    def __init__(self, job_id, working_directory, workflow_base_command):
         """
         Setup workflow
         :param job_id: int: job id we are running a workflow for
         :param working_directory: str: path to working directory that contains input files
-        :param cwl_base_command: [str] or None: array of cwl command and arguments (osx requires special arguments)
+        :param workflow_base_command: [str] or None: array of cwl command and arguments (osx requires special arguments)
         """
         self.job_id = job_id
         self.working_directory = working_directory
-        self.cwl_base_command = cwl_base_command
+        self.workflow_base_command = workflow_base_command
 
     def run(self, cwl_file_url, workflow_object_name, job_order):
         """
@@ -131,7 +131,7 @@ class CwlWorkflow(object):
         workflow_file = cwl_directory.workflow_path
         if workflow_object_name:
             workflow_file += workflow_object_name
-        process = CwlWorkflowProcess(self.cwl_base_command,
+        process = CwlWorkflowProcess(self.workflow_base_command,
                                      cwl_directory.output_directory,
                                      workflow_file,
                                      cwl_directory.job_order_file_path)
@@ -144,10 +144,10 @@ class CwlWorkflow(object):
 
 
 class CwlWorkflowProcess(object):
-    def __init__(self, cwl_base_command, local_output_directory, workflow_file, job_order_filename):
+    def __init__(self, workflow_base_command, local_output_directory, workflow_file, job_order_filename):
         """
         Setup to run cwl workflow using the supplied parameters.
-        :param cwl_base_command:  [str] or None: array of cwl command and arguments (osx requires special arguments)
+        :param workflow_base_command:  [str] or None: array of cwl command and arguments (osx requires special arguments)
         :param local_output_directory: str: path to directory we will save output files into
         :param workflow_file: str: path to the cwl workflow
         :param job_order_filename: str: path to the cwl job order (input file)
@@ -157,7 +157,7 @@ class CwlWorkflowProcess(object):
         self.return_code = None
         self.started = None
         self.finished = None
-        base_command = cwl_base_command
+        base_command = workflow_base_command
         if not base_command:
             base_command = [RUN_CWL_COMMAND]
         self.command = base_command[:]

--- a/lando/worker/staging.py
+++ b/lando/worker/staging.py
@@ -222,7 +222,6 @@ class SaveJobOutput(object):
         data_service = self.context.get_duke_data_service(self.worker_credentials)
         create_activity(data_service, self.job_details, working_directory, project)
 
-
     def _share_project(self, project):
         """
         Share project with the appropriate user since it has been uploaded.

--- a/lando/worker/tests/test_cwlworkflow.py
+++ b/lando/worker/tests/test_cwlworkflow.py
@@ -55,7 +55,7 @@ class TestCwlWorkflow(TestCase):
         """
         job_id = 1
         working_directory = tempfile.mkdtemp()
-        cwl_base_command = None
+        workflow_base_command = None
         workflow_directory = tempfile.mkdtemp()
         cwl_path = os.path.join(workflow_directory, 'workflow.cwl')
         text_to_file(SAMPLE_WORKFLOW, cwl_path)
@@ -74,7 +74,7 @@ outputfile: results.txt
         """.format(one_path, two_path)
         workflow = CwlWorkflow(job_id,
                                working_directory,
-                               cwl_base_command)
+                               workflow_base_command)
         workflow.run(cwl_file_url, workflow_object_name, input_json)
         shutil.rmtree(workflow_directory)
         shutil.rmtree(input_file_directory)
@@ -92,7 +92,7 @@ outputfile: results.txt
         """
         job_id = 1
         working_directory = tempfile.mkdtemp()
-        cwl_base_command = None
+        workflow_base_command = None
         workflow_directory = tempfile.mkdtemp()
         cwl_path = os.path.join(workflow_directory, 'workflow.cwl')
         text_to_file(SAMPLE_WORKFLOW, cwl_path)
@@ -113,7 +113,7 @@ outputfile: results.txt
         os.unlink(two_path)
         workflow = CwlWorkflow(job_id,
                                working_directory,
-                               cwl_base_command)
+                               workflow_base_command)
         with self.assertRaises(JobStepFailed):
             workflow.run(cwl_file_url, workflow_object_name, input_json)
         shutil.rmtree(workflow_directory)
@@ -127,11 +127,11 @@ outputfile: results.txt
         mock_cwl_workflow_process.return_code = 1
         job_id = '123'
         working_directory = '/tmp/job_123'
-        cwl_base_command = 'cwl-runner'
+        workflow_base_command = 'cwl-runner'
         cwl_file_url = 'file://packed.cwl'
         workflow_object_name = '#main'
         job_order = {}
-        workflow = CwlWorkflow(job_id, working_directory, cwl_base_command)
+        workflow = CwlWorkflow(job_id, working_directory, workflow_base_command)
         with self.assertRaises(JobStepFailed):
             workflow.run(cwl_file_url, workflow_object_name, job_order)
 
@@ -161,7 +161,7 @@ class TestCwlWorkflowProcess(TestCase):
         """
         Swap out cwl-runner for echo and check output
         """
-        process = CwlWorkflowProcess(cwl_base_command=['echo'],
+        process = CwlWorkflowProcess(workflow_base_command=['echo'],
                                      local_output_directory='outdir',
                                      workflow_file='workflow',
                                      job_order_filename='joborder')
@@ -175,7 +175,7 @@ class TestCwlWorkflowProcess(TestCase):
         Swap out cwl-runner for bogus ddsclient call that should fail.
         ddsclient is installed for use as a module in staging.
         """
-        process = CwlWorkflowProcess(cwl_base_command=['ddsclient'],
+        process = CwlWorkflowProcess(workflow_base_command=['ddsclient'],
                                      local_output_directory='outdir',
                                      workflow_file='workflow',
                                      job_order_filename='joborder')

--- a/lando/worker/tests/test_cwlworkflow.py
+++ b/lando/worker/tests/test_cwlworkflow.py
@@ -55,7 +55,7 @@ class TestCwlWorkflow(TestCase):
         """
         job_id = 1
         working_directory = tempfile.mkdtemp()
-        workflow_base_command = None
+        cwl_base_command = None
         workflow_directory = tempfile.mkdtemp()
         cwl_path = os.path.join(workflow_directory, 'workflow.cwl')
         text_to_file(SAMPLE_WORKFLOW, cwl_path)
@@ -74,7 +74,7 @@ outputfile: results.txt
         """.format(one_path, two_path)
         workflow = CwlWorkflow(job_id,
                                working_directory,
-                               workflow_base_command)
+                               cwl_base_command)
         workflow.run(cwl_file_url, workflow_object_name, input_json)
         shutil.rmtree(workflow_directory)
         shutil.rmtree(input_file_directory)
@@ -92,7 +92,7 @@ outputfile: results.txt
         """
         job_id = 1
         working_directory = tempfile.mkdtemp()
-        workflow_base_command = None
+        cwl_base_command = None
         workflow_directory = tempfile.mkdtemp()
         cwl_path = os.path.join(workflow_directory, 'workflow.cwl')
         text_to_file(SAMPLE_WORKFLOW, cwl_path)
@@ -113,7 +113,7 @@ outputfile: results.txt
         os.unlink(two_path)
         workflow = CwlWorkflow(job_id,
                                working_directory,
-                               workflow_base_command)
+                               cwl_base_command)
         with self.assertRaises(JobStepFailed):
             workflow.run(cwl_file_url, workflow_object_name, input_json)
         shutil.rmtree(workflow_directory)
@@ -127,11 +127,11 @@ outputfile: results.txt
         mock_cwl_workflow_process.return_code = 1
         job_id = '123'
         working_directory = '/tmp/job_123'
-        workflow_base_command = 'cwl-runner'
+        cwl_base_command = 'cwl-runner'
         cwl_file_url = 'file://packed.cwl'
         workflow_object_name = '#main'
         job_order = {}
-        workflow = CwlWorkflow(job_id, working_directory, workflow_base_command)
+        workflow = CwlWorkflow(job_id, working_directory, cwl_base_command)
         with self.assertRaises(JobStepFailed):
             workflow.run(cwl_file_url, workflow_object_name, job_order)
 
@@ -161,7 +161,7 @@ class TestCwlWorkflowProcess(TestCase):
         """
         Swap out cwl-runner for echo and check output
         """
-        process = CwlWorkflowProcess(workflow_base_command=['echo'],
+        process = CwlWorkflowProcess(cwl_base_command=['echo'],
                                      local_output_directory='outdir',
                                      workflow_file='workflow',
                                      job_order_filename='joborder')
@@ -175,7 +175,7 @@ class TestCwlWorkflowProcess(TestCase):
         Swap out cwl-runner for bogus ddsclient call that should fail.
         ddsclient is installed for use as a module in staging.
         """
-        process = CwlWorkflowProcess(workflow_base_command=['ddsclient'],
+        process = CwlWorkflowProcess(cwl_base_command=['ddsclient'],
                                      local_output_directory='outdir',
                                      workflow_file='workflow',
                                      job_order_filename='joborder')

--- a/lando/worker/tests/test_cwlworkflow.py
+++ b/lando/worker/tests/test_cwlworkflow.py
@@ -167,7 +167,8 @@ class TestCwlWorkflowProcess(TestCase):
                                      job_order_filename='joborder')
         process.run()
         self.assertEqual(0, process.return_code)
-        self.assertEqual("--outdir outdir workflow joborder", process.output.strip())
+        absolute_output_dir = os.path.abspath('outdir')
+        self.assertEqual("--outdir {} workflow joborder".format(absolute_output_dir), process.output.strip())
 
     def test_run_stderr_bad_exit(self):
         """

--- a/lando/worker/tests/test_cwlworkflow.py
+++ b/lando/worker/tests/test_cwlworkflow.py
@@ -157,7 +157,8 @@ class TestCwlDirectory(TestCase):
 
 
 class TestCwlWorkflowProcess(TestCase):
-    def test_run_stdout_good_exit(self):
+    @patch("lando.worker.cwlworkflow.os.mkdir")
+    def test_run_stdout_good_exit(self, mock_mkdir):
         """
         Swap out cwl-runner for echo and check output
         """
@@ -170,7 +171,8 @@ class TestCwlWorkflowProcess(TestCase):
         absolute_output_dir = os.path.abspath('outdir')
         self.assertEqual("--outdir {} workflow joborder".format(absolute_output_dir), process.output.strip())
 
-    def test_run_stderr_bad_exit(self):
+    @patch("lando.worker.cwlworkflow.os.mkdir")
+    def test_run_stderr_bad_exit(self, mock_mkdir):
         """
         Testing that CwlWorkflowProcess traps stderr and the bad exit code.
         Swap out cwl-runner for bogus ddsclient call that should fail.

--- a/lando/worker/tests/test_worker.py
+++ b/lando/worker/tests/test_worker.py
@@ -84,12 +84,6 @@ class FakeObject(object):
     def get_duke_ds_config(self, user_id):
         return MagicMock()
 
-    def create_activity(self, source_directory, project):
-        self.report.add("Created activity.")
-
-    def share_project(self, project):
-        self.report.add("Share project.")
-
 
 class FakeInputFile(object):
     def __init__(self, file_type):

--- a/lando/worker/tests/test_worker.py
+++ b/lando/worker/tests/test_worker.py
@@ -46,7 +46,7 @@ class FakeSettings(object):
     def make_download_url_file(self, url, destination_path):
         return FakeObject("Download url {}.".format(url), self.report)
 
-    def make_cwl_workflow(self, job_id, working_directory, workflow_base_command):
+    def make_cwl_workflow(self, job_id, working_directory, cwl_base_command):
         if self.raise_when_run_workflow:
             raise ValueError("Something went wrong.")
         obj = FakeObject("Run workflow for job {}.".format(job_id), self.report)

--- a/lando/worker/tests/test_worker.py
+++ b/lando/worker/tests/test_worker.py
@@ -46,7 +46,7 @@ class FakeSettings(object):
     def make_download_url_file(self, url, destination_path):
         return FakeObject("Download url {}.".format(url), self.report)
 
-    def make_cwl_workflow(self, job_id, working_directory, cwl_base_command):
+    def make_cwl_workflow(self, job_id, working_directory, workflow_base_command):
         if self.raise_when_run_workflow:
             raise ValueError("Something went wrong.")
         obj = FakeObject("Run workflow for job {}.".format(job_id), self.report)

--- a/lando/worker/tests/test_worker.py
+++ b/lando/worker/tests/test_worker.py
@@ -180,8 +180,6 @@ Send job step complete for job 2.
                                                       vm_instance_name='test3'))
         report = """
 Upload/share project.
-Created activity.
-Share project.
 Send job step complete for job 3 project:2348.
         """
         expected = report.strip()

--- a/lando/worker/worker.py
+++ b/lando/worker/worker.py
@@ -42,8 +42,8 @@ class LandoWorkerSettings(object):
         return staging.DownloadURLFile(url, destination_path)
 
     @staticmethod
-    def make_cwl_workflow(job_id, working_directory, cwl_base_command):
-        return cwlworkflow.CwlWorkflow(job_id, working_directory, cwl_base_command)
+    def make_cwl_workflow(job_id, working_directory, workflow_base_command):
+        return cwlworkflow.CwlWorkflow(job_id, working_directory, workflow_base_command)
 
     @staticmethod
     def make_upload_project(project_name, file_folder_list):
@@ -91,8 +91,8 @@ class LandoWorkerActions(object):
         :param working_directory: str: path to directory containing files we will run the workflow using
         :param payload: router.RunJobPayload: details about workflow to run
         """
-        cwl_base_command = self.config.cwl_base_command
-        workflow = self.settings.make_cwl_workflow(payload.job_id, working_directory, cwl_base_command)
+        workflow_base_command = self.config.workflow_base_command
+        workflow = self.settings.make_cwl_workflow(payload.job_id, working_directory, workflow_base_command)
         workflow.run(payload.cwl_file_url, payload.workflow_object_name, payload.input_json)
         self.client.job_step_complete(payload)
 

--- a/lando/worker/worker.py
+++ b/lando/worker/worker.py
@@ -105,8 +105,6 @@ class LandoWorkerActions(object):
         source_directory = os.path.join(working_directory, cwlworkflow.CWL_WORKING_DIRECTORY)
         save_job_output = self.settings.make_save_job_output(payload)
         project = save_job_output.run(source_directory)
-        save_job_output.create_activity(source_directory, project)
-        save_job_output.share_project(project)
         self.client.job_step_store_output_complete(payload, project.remote_id)
 
 

--- a/lando/worker/worker.py
+++ b/lando/worker/worker.py
@@ -42,8 +42,8 @@ class LandoWorkerSettings(object):
         return staging.DownloadURLFile(url, destination_path)
 
     @staticmethod
-    def make_cwl_workflow(job_id, working_directory, workflow_base_command):
-        return cwlworkflow.CwlWorkflow(job_id, working_directory, workflow_base_command)
+    def make_cwl_workflow(job_id, working_directory, cwl_base_command):
+        return cwlworkflow.CwlWorkflow(job_id, working_directory, cwl_base_command)
 
     @staticmethod
     def make_upload_project(project_name, file_folder_list):
@@ -91,8 +91,8 @@ class LandoWorkerActions(object):
         :param working_directory: str: path to directory containing files we will run the workflow using
         :param payload: router.RunJobPayload: details about workflow to run
         """
-        workflow_base_command = self.config.workflow_base_command
-        workflow = self.settings.make_cwl_workflow(payload.job_id, working_directory, workflow_base_command)
+        cwl_base_command = self.config.cwl_base_command
+        workflow = self.settings.make_cwl_workflow(payload.job_id, working_directory, cwl_base_command)
         workflow.run(payload.cwl_file_url, payload.workflow_object_name, payload.input_json)
         self.client.job_step_complete(payload)
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ LANDO_REQUIREMENTS = [
 ]
 
 setup(name='lando',
-      version='0.1',
+      version='0.2',
       description='Cloud based bioinformatics workflow runner',
       url='https://github.com/Duke-GCB/lando',
       author='Dan Leehr, John Bradley',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup, find_packages
 
 
 LANDO_REQUIREMENTS = [
-      "ruamel.yaml==0.15.2",
       "Babel==2.3.4",
       "shade==1.20.0",
       "cwlref-runner==1.0",


### PR DESCRIPTION
Previously the workers config file could be modified to allow running a different workflow command.
Changes here let the main __lando__ server config specify what workflow commands workers should use. 
Switching to [cwltoil](https://github.com/BD2KGenomics/toil) because it runs scatter workflows in parallel. Command line is mostly the same just minor tweaks. Stdout is different but we are not parsing this data yet.

Also found a bug where we were trying to call `create_activity` and `share_project` on SaveJobOutput. These are both handled by the SaveJobOutput `run` method now.