### PR TITLE
Share resulting project with share group

### DIFF
--- a/lando/server/jobapi.py
+++ b/lando/server/jobapi.py
@@ -132,7 +132,7 @@ class BespinApi(object):
         :param share_group: int: unique share group id
         :return: dict: details about users that need to have results shared with them
         """
-        path = 'share_group/{}'.format(share_group)
+        path = 'share-groups/{}'.format(share_group)
         url = self._make_url(path)
         return self._get_results(url)
 
@@ -242,7 +242,8 @@ class JobApi(object):
         :return: StoreOutputJobData
         """
         job_data = self.api.get_job(self.job_id)
-        share_dds_ids = self.api.get_share_dds_ids(job_data['share_group'])
+        share_group_data = self.api.get_share_dds_ids(job_data['share_group'])
+        share_dds_ids = [share_user['dds_id'] for share_user in share_group_data['users']]
         return StoreOutputJobData(job_data, share_dds_ids)
 
 

--- a/lando/server/jobapi.py
+++ b/lando/server/jobapi.py
@@ -126,6 +126,16 @@ class BespinApi(object):
         resp.raise_for_status()
         return resp.json()
 
+    def get_share_dds_ids(self, share_group):
+        """
+        Get the list of users who are part of a share_group (should have job results shared with them).
+        :param share_group: int: unique share group id
+        :return: dict: details about users that need to have results shared with them
+        """
+        path = 'share_group/{}'.format(share_group)
+        url = self._make_url(path)
+        return self._get_results(url)
+
 
 class JobApi(object):
     """
@@ -226,6 +236,15 @@ class JobApi(object):
             result.append(Job(job_dict))
         return result
 
+    def get_store_output_job_data(self):
+        """
+        Get Job data for use with storing output
+        :return: StoreOutputJobData
+        """
+        job_data = self.api.get_job(self.job_id)
+        share_dds_ids = self.api.get_share_dds_ids(job_data['share_group'])
+        return StoreOutputJobData(job_data, share_dds_ids)
+
 
 class Job(object):
     """
@@ -249,6 +268,15 @@ class Job(object):
         self.workflow = Workflow(data)
         self.output_project = OutputProject(data)
         self.volume_size = data['volume_size']
+
+
+class StoreOutputJobData(Job):
+    """
+    Job data plus a list of dds user ids to share results with
+    """
+    def __init__(self, job_data, share_dds_ids):
+        super(StoreOutputJobData, self).__init__(job_data)
+        self.share_dds_ids = share_dds_ids
 
 
 class Workflow(object):

--- a/lando/server/lando.py
+++ b/lando/server/lando.py
@@ -172,9 +172,9 @@ class JobActions(object):
         self._set_job_step(JobSteps.STORING_JOB_OUTPUT)
         self._show_status("Storing job output")
         credentials = self.job_api.get_credentials()
-        job = self.job_api.get_job()
+        job_data = self.job_api.get_store_output_job_data()
         worker_client = self.make_worker_client(payload.vm_instance_name)
-        worker_client.store_job_output(credentials, job, payload.vm_instance_name)
+        worker_client.store_job_output(credentials, job_data, payload.vm_instance_name)
 
     def store_job_output_complete(self, payload):
         """

--- a/lando/server/tests/test_jobapi.py
+++ b/lando/server/tests/test_jobapi.py
@@ -31,6 +31,7 @@ class TestJobApi(TestCase):
                 'dds_user_credentials': 123
             },
             'stage_group': None,
+            'share_group': 42,
             'volume_size': 100
         }
 
@@ -261,3 +262,42 @@ class TestJobApi(TestCase):
         job = Job(payload)
         self.assertEqual(job.volume_size, 1000,
                          "A job payload with volume_size should result in that volume size.")
+
+    @patch('lando.server.jobapi.requests')
+    def test_get_store_output_job_data(self, mock_requests):
+        """
+        Test requesting job status, etc
+        """
+        job_api = self.setup_job_api(1)
+
+        mock_job_get_response = MagicMock()
+        mock_job_get_response.json.return_value = self.job_response_payload
+
+        mock_share_group_response = MagicMock()
+        mock_share_group_response.json.return_value = {
+            'users': [
+                {
+                    'dds_id': '123'
+                }
+            ]
+        }
+
+        mock_requests.get.side_effect = [
+            mock_job_get_response,
+            mock_share_group_response
+        ]
+        store_output_data = job_api.get_store_output_job_data()
+
+        self.assertEqual(1, store_output_data.id)
+        self.assertEqual(23, store_output_data.user_id)
+        self.assertEqual('joe@joe.com', store_output_data.username)
+        self.assertEqual('N', store_output_data.state)
+        self.assertEqual('m1.tiny', store_output_data.vm_flavor)
+        self.assertEqual('', store_output_data.vm_instance_name)
+        self.assertEqual('jpb67', store_output_data.vm_project_name)
+
+        self.assertEqual('{ "value": 1 }', store_output_data.workflow.job_order)
+        self.assertEqual('file:///mnt/fastqc.cwl', store_output_data.workflow.url)
+        self.assertEqual('#main', store_output_data.workflow.object_name)
+
+        self.assertEqual(['123'], store_output_data.share_dds_ids)

--- a/lando/worker/staging.py
+++ b/lando/worker/staging.py
@@ -125,7 +125,7 @@ class DukeDataService(object):
         """
         d4s2_project = D4S2Project(self.config, self.remote_store,
                                    print_func=print)  # D4S2Project doesn't use print_func for share
-        remote_user = self.data_service.get_user_by_id(dds_user_id)
+        remote_user = self.remote_store.fetch_user(dds_user_id)
         d4s2_project.share(project_name,
                            remote_user,
                            force_send=False,

--- a/lando/worker/staging.py
+++ b/lando/worker/staging.py
@@ -1,6 +1,7 @@
 """
 Downloads input files and uploads output directory.
 """
+from __future__ import print_function
 import os
 import re
 import requests
@@ -12,6 +13,7 @@ from ddsc.core.download import ProjectDownload
 from ddsc.core.filedownloader import FileDownloader
 from ddsc.core.util import KindType
 from ddsc.core.upload import ProjectUpload
+from ddsc.core.d4s2 import D4S2Project
 from lando.worker.provenance import create_activity
 
 DOWNLOAD_URL_CHUNK_SIZE = 5 * 1024 # 5KB
@@ -114,6 +116,21 @@ class DukeDataService(object):
     def get_file_version_id(self, file_id):
         file_info = self.data_service.get_file(file_id).json()
         return file_info['current_version']['id']
+
+    def share_project(self, project_name, dds_user_id):
+        """
+        Share a project with a specific dds user
+        :param project_name: str: unique name of the project
+        :param dds_user_id: str: DukeDS user id
+        """
+        d4s2_project = D4S2Project(self.config, self.remote_store,
+                                   print_func=print)  # D4S2Project doesn't use print_func for share
+        remote_user = self.data_service.get_user_by_id(dds_user_id)
+        d4s2_project.share(project_name,
+                           remote_user,
+                           force_send=False,
+                           auth_role='project_admin',
+                           user_message='Bespin job results.')
 
 
 class DownloadDukeDSFile(object):
@@ -228,9 +245,8 @@ class SaveJobOutput(object):
         :param project: ddsc.core.localproject.LocalProject: contains ids of uploaded projects
         """
         data_service = self.context.get_duke_data_service(self.worker_credentials)
-        data_service.give_user_permissions(project.remote_id,
-                                           self.get_dukeds_username(),
-                                           auth_role='project_admin')
+        for dds_user_id in  self.job_details.share_dds_ids:
+            data_service.share_project(self.project_name, dds_user_id)
 
     def get_dukeds_username(self):
         """

--- a/lando/worker/tests/test_staging.py
+++ b/lando/worker/tests/test_staging.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 from unittest import TestCase
 from lando.worker.staging import SaveJobOutput
-from mock import patch, Mock, MagicMock
+from mock import patch, Mock, MagicMock, call
 
 
 class TestSaveJobOutput(TestCase):
@@ -12,6 +12,7 @@ class TestSaveJobOutput(TestCase):
         payload.job_details.name = 'MyJob'
         payload.job_details.created = '2017-03-21T13:29:09.123603Z'
         payload.job_details.username = 'john@john.org'
+        payload.job_details.share_dds_ids = ['123','456']
         self.payload = payload
 
     def test_create_project_name(self):
@@ -43,6 +44,8 @@ class TestSaveJobOutput(TestCase):
         data_service.create_generated_by_relations.assert_called()
 
         # We should give permissions to the user
-        give_user_permissions = data_service.give_user_permissions
-        give_user_permissions.assert_called_with(mock_project_upload().local_project.remote_id, 'john',
-                                                 auth_role='project_admin')
+        share_project = data_service.share_project
+        share_project.assert_has_calls([
+            call('Bespin SomeWorkflow v2 MyJob 2017-03-21', '123'),
+            call('Bespin SomeWorkflow v2 MyJob 2017-03-21', '456')
+        ])

--- a/lando/worker/tests/test_staging.py
+++ b/lando/worker/tests/test_staging.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 from unittest import TestCase
-from lando.worker.staging import SaveJobOutput
+from lando.worker.staging import SaveJobOutput, DukeDataService
 from mock import patch, Mock, MagicMock, call
 
 
@@ -49,3 +49,16 @@ class TestSaveJobOutput(TestCase):
             call('Bespin SomeWorkflow v2 MyJob 2017-03-21', '123'),
             call('Bespin SomeWorkflow v2 MyJob 2017-03-21', '456')
         ])
+
+
+class TestDukeDataService(TestCase):
+    @patch('lando.worker.staging.D4S2Project')
+    @patch('lando.worker.staging.RemoteStore')
+    def test_share_project(self, mock_remote_store, mock_d4s2_project):
+        remote_user = Mock(id='132')
+        mock_remote_store.return_value.fetch_user.return_value = remote_user
+        data_service = DukeDataService(MagicMock())
+        data_service.share_project('my_project', remote_user.id)
+        mock_d4s2_project.return_value.share.assert_called_with('my_project', remote_user,
+                                                                auth_role='project_admin', force_send=False,
+                                                                user_message='Bespin job results.')


### PR DESCRIPTION
During the store output step the lando worker will share the project with every user in the share group. 

NOTE: This requires the lando user to have an email template setup in D4S2.