### PR TITLE
Update fs_setup section in cloudconfig

### DIFF
--- a/lando/server/cloudconfigscript.py
+++ b/lando/server/cloudconfigscript.py
@@ -26,8 +26,8 @@ class CloudConfigScript(object):
 
         self._content_dict['disk_setup'][device] = disk_setup
 
-    def _add_fs_setup(self, device, label=None, fs_type='ext3', part_value='auto'):
-        fs_setup = {'filesystem': fs_type, 'device': device, 'partition': part_value}
+    def _add_fs_setup(self, device, label=None, fs_type='ext3'):
+        fs_setup = {'filesystem': fs_type, 'device': device}
         if label:
             fs_setup['label'] = label
         self._content_dict['fs_setup'].append(fs_setup)
@@ -47,7 +47,7 @@ class CloudConfigScript(object):
         """
         device = self.device_name(partition)
         self._set_disk_setup(device)
-        self._add_fs_setup(device, part_value=partition)
+        self._add_fs_setup(partition)
         self._add_mount(partition, mount_point)
 
     @staticmethod

--- a/lando/server/tests/test_cloudconfigscript.py
+++ b/lando/server/tests/test_cloudconfigscript.py
@@ -24,7 +24,7 @@ write_files:
 disk_setup:
   /dev/vdg: {layout: true, table_type: gpt}
 fs_setup:
-- {device: /dev/vdg, filesystem: ext3, partition: /dev/vdg1}
+- {device: /dev/vdg1, filesystem: ext3}
 mounts:
 - [/dev/vdg1, /mnt/data]
 """


### PR DESCRIPTION
- Specifying the device and partition, while documented in http://cloudinit.readthedocs.io/en/latest/topics/examples.html#disk-setup does not work here.
- Instead just specify the partition as the device in fs_setup

I tested the generated configs in a jupyter notebook using shade. This works, and I confirmed the previous configs do not.