### PR TITLE
reorganize output project based on user feedback

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,4 @@
 dependencies:
   pre:
     - pip install mock
+    - pip install shade

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,3 @@
 dependencies:
   pre:
     - pip install mock
-    - pip install shade

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,3 @@
 dependencies:
   pre:
     - pip install mock
-    - pip install pbr

--- a/lando/worker/cwlworkflow.py
+++ b/lando/worker/cwlworkflow.py
@@ -26,7 +26,6 @@ JOB_STDERR_FILENAME = 'cwltool-output.log'
 JOB_DATA_FILENAME = 'job-data.json'
 
 WORKFLOW_DIRECTORY = 'scripts'
-OUTPUT_DIRECTORY = 'output'
 
 
 CWL_WORKING_DIRECTORY = 'working'
@@ -78,7 +77,6 @@ class CwlDirectory(object):
         self.working_directory = working_directory
         self.result_directory = os.path.join(working_directory, CWL_WORKING_DIRECTORY)
         create_dir_if_necessary(self.result_directory)
-        self.output_directory = os.path.join(self.result_directory, OUTPUT_DIRECTORY)
         self.workflow_basename = os.path.basename(cwl_file_url)
         self.workflow_path = self._add_workflow_file(cwl_file_url)
         job_order_filename = self._get_job_order_filename(job_id)

--- a/lando/worker/cwlworkflow.py
+++ b/lando/worker/cwlworkflow.py
@@ -132,7 +132,7 @@ class CwlWorkflow(object):
         if workflow_object_name:
             workflow_file += workflow_object_name
         process = CwlWorkflowProcess(self.cwl_base_command,
-                                     cwl_directory.output_directory,
+                                     os.path.join(cwl_directory.result_directory, RESULTS_DIRECTORY),
                                      workflow_file,
                                      cwl_directory.job_order_file_path)
         process.run()
@@ -174,6 +174,7 @@ class CwlWorkflowProcess(object):
         if not os.path.exists(self.absolute_output_directory):
             os.mkdir(self.absolute_output_directory)
         self.started = datetime.datetime.now()
+        print(self.command)
         p = Popen(self.command, stderr=PIPE, stdout=PIPE)
         (stdout_data, stderr_data) = p.communicate()
         self.output = stdout_data

--- a/lando/worker/cwlworkflow.py
+++ b/lando/worker/cwlworkflow.py
@@ -17,7 +17,7 @@ RUN_CWL_COMMAND = "cwl-runner"
 RUN_CWL_OUTDIR_ARG = "--outdir"
 
 RESULTS_DIRECTORY = 'results'
-DOCUMENTATION_DIRECTORY = 'documentation'
+DOCUMENTATION_DIRECTORY = 'docs'
 README_FILENAME = 'README'
 
 LOGS_DIRECTORY = 'logs'
@@ -197,9 +197,9 @@ class ResultsDirectory(object):
 
     Fills in the following directory structure:
     working_directory/            # base directory for this job
-        results/           # this is a user specified name (this directory is uploaded in the store output stage)
+        results/           # this directory is uploaded in the store output stage
            ...output files from workflow
-           documentation/
+           docs/
               README         # describes contents of the upload_directory
               logs/
                   cwltool-output.json   #stdout from cwl-runner - json job results

--- a/lando/worker/provenance.py
+++ b/lando/worker/provenance.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import os
 import json
-from lando.worker.cwlworkflow import OUTPUT_DIRECTORY, WORKFLOW_DIRECTORY, LOGS_DIRECTORY, JOB_DATA_FILENAME
+from lando.worker.cwlworkflow import WORKFLOW_DIRECTORY, LOGS_DIRECTORY, JOB_DATA_FILENAME
 from ddsc.core.util import KindType
 
 
@@ -21,7 +21,7 @@ class WorkflowFiles(object):
         Get absolute paths for all files in the output directory.
         :return: [str]: list of file paths
         """
-        output_dirname = os.path.join(self.working_directory, OUTPUT_DIRECTORY)
+        output_dirname = os.path.join(self.working_directory)
         output_filenames = []
         for root, dirnames, filenames in os.walk(output_dirname):
             for filename in filenames:

--- a/lando/worker/provenance.py
+++ b/lando/worker/provenance.py
@@ -1,7 +1,8 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import json
-from lando.worker.cwlworkflow import WORKFLOW_DIRECTORY, LOGS_DIRECTORY, JOB_DATA_FILENAME
+from lando.worker.cwlworkflow import RESULTS_DIRECTORY, DOCUMENTATION_DIRECTORY, WORKFLOW_DIRECTORY, LOGS_DIRECTORY, \
+    JOB_DATA_FILENAME
 from ddsc.core.util import KindType
 
 
@@ -12,7 +13,8 @@ class WorkflowFiles(object):
         :param job_id: int: unique id for the job
         :param workflow_filename: str: name of the workflow file
         """
-        self.working_directory = working_directory
+        self.results_directory = os.path.join(working_directory, RESULTS_DIRECTORY)
+        self.docs_directory = os.path.join(self.results_directory, DOCUMENTATION_DIRECTORY)
         self.job_id = job_id
         self.workflow_filename = workflow_filename
 
@@ -21,9 +23,10 @@ class WorkflowFiles(object):
         Get absolute paths for all files in the output directory.
         :return: [str]: list of file paths
         """
-        output_dirname = os.path.join(self.working_directory)
         output_filenames = []
-        for root, dirnames, filenames in os.walk(output_dirname):
+        for root, dirnames, filenames in os.walk(self.results_directory):
+            if root.startswith(self.docs_directory):
+                continue
             for filename in filenames:
                 full_filename = self._format_filename(os.path.join(root, filename))
                 output_filenames.append(full_filename)
@@ -34,7 +37,7 @@ class WorkflowFiles(object):
         Get absolute paths for the workflow and job input files.
         :return: [str]: list of file paths
         """
-        scripts_dirname = os.path.join(self.working_directory, WORKFLOW_DIRECTORY)
+        scripts_dirname = os.path.join(self.docs_directory, WORKFLOW_DIRECTORY)
         workflow_path = os.path.join(scripts_dirname, self.workflow_filename)
         job_input_path = os.path.join(scripts_dirname, 'job-{}-input.yml'.format(self.job_id))
         return [
@@ -43,7 +46,7 @@ class WorkflowFiles(object):
         ]
 
     def get_job_data(self):
-        job_data_path = os.path.join(self.working_directory, LOGS_DIRECTORY, JOB_DATA_FILENAME)
+        job_data_path = os.path.join(self.docs_directory, LOGS_DIRECTORY, JOB_DATA_FILENAME)
         with open(job_data_path, 'r') as infile:
             return json.load(infile)
 

--- a/lando/worker/tests/test_cwlworkflow.py
+++ b/lando/worker/tests/test_cwlworkflow.py
@@ -214,27 +214,28 @@ class TestResultsDirectory(TestCase):
 
         # Ask directory to add files based on a mock process
         results_directory.add_files(cwl_process)
+        documentation_directory = '/tmp/fakedir/results/documentation/'
 
         mock_create_dir_if_necessary.assert_has_calls([
-            call("/tmp/fakedir/logs"),
-            call("/tmp/fakedir/scripts")])
+            call(documentation_directory + "logs"),
+            call(documentation_directory + "scripts")])
         mock_save_data_to_directory.assert_has_calls([
-            call('/tmp/fakedir/logs', 'cwltool-output.json', 'stdoutdata'),
-            call('/tmp/fakedir/logs', 'cwltool-output.log', 'stderrdata')])
+            call(documentation_directory + 'logs', 'cwltool-output.json', 'stdoutdata'),
+            call(documentation_directory + 'logs', 'cwltool-output.log', 'stderrdata')])
         mock_shutil.copy.assert_has_calls([
-            call('/tmp/nosuchpath.cwl', '/tmp/fakedir/scripts/nosuch.cwl'),
-            call('/tmp/alsonotreal.json', '/tmp/fakedir/scripts/alsonotreal.json')
+            call('/tmp/nosuchpath.cwl', documentation_directory + 'scripts/nosuch.cwl'),
+            call('/tmp/alsonotreal.json', documentation_directory + 'scripts/alsonotreal.json')
         ])
         mock_create_workflow_info.assert_has_calls([
-            call(workflow_path='/tmp/fakedir/scripts/nosuch.cwl'),
-            call().update_with_job_order(job_order_path='/tmp/fakedir/scripts/alsonotreal.json'),
-            call().update_with_job_output(job_output_path='/tmp/fakedir/logs/cwltool-output.json'),
+            call(workflow_path=(documentation_directory + 'scripts/nosuch.cwl')),
+            call().update_with_job_order(job_order_path=(documentation_directory + 'scripts/alsonotreal.json')),
+            call().update_with_job_output(job_output_path=(documentation_directory + 'logs/cwltool-output.json')),
             call().count_output_files(),
             call().total_file_size_str()
         ])
         mock_cwl_report().save.assert_has_calls([
-            call('/tmp/fakedir/README')
+            call(documentation_directory + 'README')
         ])
         mock_scripts_readme().save.assert_has_calls([
-            call('/tmp/fakedir/scripts/README')
+            call(documentation_directory + 'scripts/README')
         ])

--- a/lando/worker/tests/test_cwlworkflow.py
+++ b/lando/worker/tests/test_cwlworkflow.py
@@ -213,7 +213,7 @@ class TestResultsDirectory(TestCase):
 
         # Ask directory to add files based on a mock process
         results_directory.add_files(cwl_process)
-        documentation_directory = '/tmp/fakedir/results/documentation/'
+        documentation_directory = '/tmp/fakedir/results/docs/'
 
         mock_create_dir_if_necessary.assert_has_calls([
             call(documentation_directory + "logs"),

--- a/lando/worker/tests/test_cwlworkflow.py
+++ b/lando/worker/tests/test_cwlworkflow.py
@@ -4,7 +4,7 @@ import os
 import tempfile
 import shutil
 from lando.testutil import text_to_file, file_to_text
-from lando.worker.cwlworkflow import CwlWorkflow, OUTPUT_DIRECTORY
+from lando.worker.cwlworkflow import CwlWorkflow, RESULTS_DIRECTORY
 from lando.worker.cwlworkflow import CwlDirectory, CwlWorkflowProcess, ResultsDirectory
 from mock import patch, MagicMock, call
 from lando.exceptions import JobStepFailed
@@ -81,7 +81,7 @@ outputfile: results.txt
 
         result_file_content = file_to_text(os.path.join(working_directory,
                                                         'working',
-                                                        OUTPUT_DIRECTORY,
+                                                        RESULTS_DIRECTORY,
                                                         "results.txt"))
         self.assertEqual(result_file_content, "one\ntwo\n")
         shutil.rmtree(working_directory)
@@ -151,7 +151,6 @@ class TestCwlDirectory(TestCase):
         self.assertEqual(working_directory, cwl_directory.working_directory)
         self.assertEqual('/tmp/fakedir/working', cwl_directory.result_directory)
         mock_create_dir_if_necessary.assert_called_with('/tmp/fakedir/working')
-        self.assertEqual('/tmp/fakedir/working/output', cwl_directory.output_directory)
         self.assertEqual('/tmp/fakedir/notreal.cwl', cwl_directory.workflow_path)
         self.assertEqual('somepath', cwl_directory.job_order_file_path)
 

--- a/lando/worker/tests/test_provenance.py
+++ b/lando/worker/tests/test_provenance.py
@@ -13,11 +13,12 @@ class TestWorkflowFiles(TestCase):
         ]
         expected_filenames = ['/tmp/data.txt', '/tmp/data2.txt']
         self.assertEqual(expected_filenames, workflow_files.get_output_filenames())
-        mock_walk.assert_called_with('/tmp/output')
+        mock_walk.assert_called_with('/tmp/results')
 
     def test_get_input_filenames(self):
         workflow_files = WorkflowFiles(working_directory='/tmp', job_id=1, workflow_filename="fastqc.cwl")
-        expected_filenames = ['/tmp/scripts/fastqc.cwl', '/tmp/scripts/job-1-input.yml']
+        expected_filenames = ['/tmp/results/documentation/scripts/fastqc.cwl',
+                              '/tmp/results/documentation/scripts/job-1-input.yml']
         self.assertEqual(expected_filenames, workflow_files.get_input_filenames())
 
     def test_get_job_data(self):
@@ -45,9 +46,9 @@ class TestDukeDSProjectInfo(TestCase):
 
 class TestWorkflowActivity(TestCase):
     def setUp(self):
-        mock_file1 = Mock(kind='dds-file', remote_id='123', path='/tmp/scripts/example.cwl')
-        mock_file2 = Mock(kind='dds-file', remote_id='124', path='/tmp/scripts/job-444-input.yml')
-        mock_file3 = Mock(kind='dds-file', remote_id='125', path='/tmp/output/data.txt')
+        mock_file1 = Mock(kind='dds-file', remote_id='123', path='/tmp/results/documentation/scripts/example.cwl')
+        mock_file2 = Mock(kind='dds-file', remote_id='124', path='/tmp/results/documentation/scripts/job-444-input.yml')
+        mock_file3 = Mock(kind='dds-file', remote_id='125', path='/tmp/results/data.txt')
         mock_folder1 = Mock(name='scripts', kind='dds-folder', children=[mock_file1, mock_file2])
         mock_folder2 = Mock(name='output', kind='dds-folder', children=[mock_file3])
         self.mock_project = Mock(kind='dds-project', children=[mock_folder1, mock_folder2])
@@ -81,7 +82,7 @@ class TestWorkflowActivity(TestCase):
 
     @patch('lando.worker.provenance.WorkflowFiles')
     def test_generated_file_ids_returns_output_files(self, mock_workflow_files):
-        mock_workflow_files.return_value.get_output_filenames.return_value = ['/tmp/output/data.txt']
+        mock_workflow_files.return_value.get_output_filenames.return_value = ['/tmp/results/data.txt']
         workflow_activity = WorkflowActivity(
             job_details=Mock(id='444', workflow=Mock(name='RnaSeq', version='1', url='http://something/example.cwl')),
             working_directory='/tmp/',

--- a/lando/worker/tests/test_provenance.py
+++ b/lando/worker/tests/test_provenance.py
@@ -8,14 +8,14 @@ class TestWorkflowFiles(TestCase):
     def test_constructor_directory_properties(self):
         workflow_files = WorkflowFiles(working_directory='/tmp', job_id=1, workflow_filename="fastqc.cwl")
         self.assertEqual('/tmp/results', workflow_files.results_directory)
-        self.assertEqual('/tmp/results/documentation', workflow_files.docs_directory)
+        self.assertEqual('/tmp/results/docs', workflow_files.docs_directory)
 
     @patch('lando.worker.provenance.os.walk')
     def test_get_output_filenames(self, mock_walk):
         workflow_files = WorkflowFiles(working_directory='/tmp', job_id=1, workflow_filename="fastqc.cwl")
         mock_walk.return_value = [
             ('/tmp', '', ['data.txt', 'data2.txt']),
-            ('/tmp/results/documentation', '', ['README'])
+            ('/tmp/results/docs', '', ['README'])
         ]
         expected_filenames = ['/tmp/data.txt', '/tmp/data2.txt']
         self.assertEqual(expected_filenames, workflow_files.get_output_filenames())
@@ -23,8 +23,8 @@ class TestWorkflowFiles(TestCase):
 
     def test_get_input_filenames(self):
         workflow_files = WorkflowFiles(working_directory='/tmp', job_id=1, workflow_filename="fastqc.cwl")
-        expected_filenames = ['/tmp/results/documentation/scripts/fastqc.cwl',
-                              '/tmp/results/documentation/scripts/job-1-input.yml']
+        expected_filenames = ['/tmp/results/docs/scripts/fastqc.cwl',
+                              '/tmp/results/docs/scripts/job-1-input.yml']
         self.assertEqual(expected_filenames, workflow_files.get_input_filenames())
 
     def test_get_job_data(self):
@@ -33,7 +33,7 @@ class TestWorkflowFiles(TestCase):
         fake_open = mock_open(read_data=read_data)
         with patch("__builtin__.open", fake_open) as mock_file:
             job_data = workflow_files.get_job_data()
-            self.assertEqual(call('/tmp/results/documentation/logs/job-data.json', 'r'),
+            self.assertEqual(call('/tmp/results/docs/logs/job-data.json', 'r'),
                              fake_open.call_args_list[0])
         expected_job_data = {
             "started": "2017-06-01:0800",
@@ -55,8 +55,8 @@ class TestDukeDSProjectInfo(TestCase):
 
 class TestWorkflowActivity(TestCase):
     def setUp(self):
-        mock_file1 = Mock(kind='dds-file', remote_id='123', path='/tmp/results/documentation/scripts/example.cwl')
-        mock_file2 = Mock(kind='dds-file', remote_id='124', path='/tmp/results/documentation/scripts/job-444-input.yml')
+        mock_file1 = Mock(kind='dds-file', remote_id='123', path='/tmp/results/docs/scripts/example.cwl')
+        mock_file2 = Mock(kind='dds-file', remote_id='124', path='/tmp/results/docs/scripts/job-444-input.yml')
         mock_file3 = Mock(kind='dds-file', remote_id='125', path='/tmp/results/data.txt')
         mock_folder1 = Mock(name='scripts', kind='dds-folder', children=[mock_file1, mock_file2])
         mock_folder2 = Mock(name='output', kind='dds-folder', children=[mock_file3])

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 LANDO_REQUIREMENTS = [
       "Babel==2.3.4",
-      "shade==1.20.0",
+      "shade==1.23.0",
       "cwlref-runner==1.0",
       "DukeDSClient==0.3.17",
       "humanfriendly==2.4",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup, find_packages
 
 
 LANDO_REQUIREMENTS = [
-      "Babel==2.3.4",
       "shade==1.23.0",
       "cwlref-runner==1.0",
       "DukeDSClient==0.3.17",


### PR DESCRIPTION
Fixes #69 
Old format:
```
README
results/
    ...output files from workflow
logs/
    cwltool-output.json   #stdout from cwl-runner - json job results
    cwltool-output.log    #stderr from cwl-runner
    job-data.json         # non-cwl job data used to create Bespin-Report.txt
workflow/
    workflow.cwl            # cwl workflow we will run
    workflow.yml            # job order input file
```

New format:
```
results/
    ...output files from workflow
    documentation/
        README
        logs/
            cwltool-output.json   #stdout from cwl-runner - json job results
            cwltool-output.log    #stderr from cwl-runner
            job-data.json         # non-cwl job data used to create Bespin-Report.txt
        workflow/
            workflow.cwl            # cwl workflow we will run
            workflow.yml            # job order input file
```
