### PR TITLE
Ddsclient upgrade fix

### DIFF
--- a/lando/worker/staging.py
+++ b/lando/worker/staging.py
@@ -81,8 +81,7 @@ class DukeDataService(object):
         """
         file_data = self.data_service.get_file(file_id).json()
         remote_file = RemoteFile(file_data, '')
-        url_json = self.data_service.get_file_url(file_id).json()
-        downloader = FileDownloader(self.config, remote_file, url_json, destination_path, self)
+        downloader = FileDownloader(self.config, remote_file, destination_path, self)
         downloader.run()
         ProjectDownload.check_file_size(remote_file, destination_path)
 

--- a/lando/worker/tests/test_staging.py
+++ b/lando/worker/tests/test_staging.py
@@ -62,3 +62,16 @@ class TestDukeDataService(TestCase):
         mock_d4s2_project.return_value.share.assert_called_with('my_project', remote_user,
                                                                 auth_role='project_admin', force_send=False,
                                                                 user_message='Bespin job results.')
+
+    @patch('lando.worker.staging.D4S2Project')
+    @patch('lando.worker.staging.RemoteStore')
+    @patch('lando.worker.staging.RemoteFile')
+    @patch('lando.worker.staging.FileDownloader')
+    @patch('lando.worker.staging.ProjectDownload')
+    def test_download_file(self, mock_project_download, mock_file_downloader, mock_remote_file, mock_remote_store,
+                           mock_d4s2_project):
+        remote_user = Mock(id='132')
+        mock_remote_store.return_value.fetch_user.return_value = remote_user
+        data_service = DukeDataService(MagicMock())
+        data_service.download_file('123', '/tmp/data.txt')
+        mock_file_downloader.return_value.run.assert_called()


### PR DESCRIPTION
Fixes #73 
We no longer needed to pass url returned by DukeDS to the FileDownloader as it now does that right before it's needed in the latest version of DukeDSClient.