### PR TITLE
Configurable logging

### DIFF
--- a/integration_test/worker_config.yml
+++ b/integration_test/worker_config.yml
@@ -7,3 +7,4 @@ cwl_base_command:
   - "--debug"
   - "--tmpdir-prefix=/Users/jpb67/Documents/work/tmp"
   - "--tmp-outdir-prefix=/Users/jpb67/Documents/work/tmp"
+log_level: INFO

--- a/lando/server/__main__.py
+++ b/lando/server/__main__.py
@@ -4,10 +4,10 @@ Starts VMs and has them run various job stages.
 """
 from __future__ import print_function, absolute_import
 import os
+import sys
+import logging
 from lando.server.config import ServerConfig
 from lando.server.lando import Lando, CONFIG_FILE_NAME
-import logging
-ROOT_LOGFILE_NAME = '/tmp/lando-server.log'
 
 
 def main():
@@ -15,7 +15,7 @@ def main():
     if not config_filename:
         config_filename = CONFIG_FILE_NAME
     config = ServerConfig(config_filename)
-    logging.basicConfig(filename=ROOT_LOGFILE_NAME, level=config.log_level)
+    logging.basicConfig(stream=sys.stdout, level=config.log_level)
     lando = Lando(config)
     lando.listen_for_messages()
 

--- a/lando/server/__main__.py
+++ b/lando/server/__main__.py
@@ -6,6 +6,8 @@ from __future__ import print_function, absolute_import
 import os
 from lando.server.config import ServerConfig
 from lando.server.lando import Lando, CONFIG_FILE_NAME
+import logging
+ROOT_LOGFILE_NAME = '/tmp/lando-server.log'
 
 
 def main():
@@ -13,6 +15,7 @@ def main():
     if not config_filename:
         config_filename = CONFIG_FILE_NAME
     config = ServerConfig(config_filename)
+    logging.basicConfig(filename=ROOT_LOGFILE_NAME, level=config.log_level)
     lando = Lando(config)
     lando.listen_for_messages()
 

--- a/lando/server/config.py
+++ b/lando/server/config.py
@@ -4,6 +4,7 @@ Reads configuration settings from a YAML file for use with lando
 from __future__ import absolute_import
 import yaml
 from lando.exceptions import get_or_raise_config_exception, InvalidConfigException
+import logging
 
 
 class ServerConfig(object):
@@ -25,6 +26,7 @@ class ServerConfig(object):
             self.vm_settings = self._optional_get(data, 'vm_settings', VMSettings)
             self.cloud_settings = self._optional_get(data, 'cloud_settings', CloudSettings)
             self.bespin_api_settings = self._optional_get(data, 'bespin_api', BespinApiSettings)
+            self.log_level = data.get('log_level', logging.WARNING)
 
     @staticmethod
     def _optional_get(data, name, constructor):
@@ -114,5 +116,3 @@ class BespinApiSettings(object):
     def __init__(self, data):
         self.url = get_or_raise_config_exception(data, 'url')
         self.token = get_or_raise_config_exception(data, 'token')
-
-

--- a/lando/server/lando.py
+++ b/lando/server/lando.py
@@ -5,6 +5,7 @@ from __future__ import print_function, absolute_import
 from datetime import datetime
 import traceback
 import json
+import logging
 from lando.server.jobapi import JobApi, JobStates, JobSteps
 from lando.server.cloudconfigscript import CloudConfigScript
 from lando.server.cloudservice import CloudService, FakeCloudService
@@ -276,7 +277,7 @@ class JobActions(object):
 
     def _show_status(self, message):
         format_str = "{}: {} for job: {}."
-        print(format_str.format(datetime.now(), message, self.job_id))
+        logging.info(format_str.format(datetime.now(), message, self.job_id))
 
     def generic_job_error(self, action_name, details):
         """
@@ -347,7 +348,7 @@ class Lando(object):
         Blocks and waits for messages on the queue specified in config.
         """
         router = self._make_router()
-        print("Lando listening for messages on queue '{}'.".format(router.queue_name))
+        logging.info("Lando listening for messages on queue '{}'.".format(router.queue_name))
         router.run()
 
     def _make_router(self):

--- a/lando/server/tests/test_config.py
+++ b/lando/server/tests/test_config.py
@@ -1,5 +1,6 @@
 from unittest import TestCase
 import os
+import logging
 from lando.testutil import write_temp_return_filename
 from lando.server.config import ServerConfig
 from lando.exceptions import InvalidConfigException
@@ -59,7 +60,7 @@ class TestServerConfig(TestCase):
 
         self.assertEqual("http://localhost:8000/api", config.bespin_api_settings.url)
         self.assertEqual("10498124091240e", config.bespin_api_settings.token)
-
+        self.assertEqual(logging.WARNING, config.log_level)
 
     def test_allocate_floating_ip_true(self):
         line = "  allocate_floating_ips: true"
@@ -125,3 +126,9 @@ username: lobot
         result = config.make_worker_config_yml('worker_1')
         self.assertMultiLineEqual(expected.strip(), result.strip())
         self.assertEqual(['cwltoil', '--not-strict'], config.vm_settings.cwl_base_command)
+
+    def test_log_level(self):
+        filename = write_temp_return_filename(GOOD_CONFIG.format('log_level: INFO'))
+        config = ServerConfig(filename)
+        self.assertEqual('INFO', config.log_level)
+        os.unlink(filename)

--- a/lando/worker/__main__.py
+++ b/lando/worker/__main__.py
@@ -7,6 +7,9 @@ import os
 from lando.worker.config import WorkerConfig
 from lando.worker.worker import CONFIG_FILE_NAME, LandoWorker, LandoWorkerSettings
 from lando.server.lando import LANDO_QUEUE_NAME
+import logging
+
+ROOT_LOGFILE_NAME = '/tmp/lando-worker.log'
 
 
 def main():
@@ -14,6 +17,7 @@ def main():
     if not config_filename:
         config_filename = CONFIG_FILE_NAME
     config = WorkerConfig(config_filename)
+    logging.basicConfig(filename=ROOT_LOGFILE_NAME, level=config.log_level)
     settings = LandoWorkerSettings(config)
     worker = LandoWorker(settings, outgoing_queue_name=LANDO_QUEUE_NAME)
     worker.listen_for_messages()

--- a/lando/worker/config.py
+++ b/lando/worker/config.py
@@ -3,6 +3,7 @@ Configuration for for use with lando_worker.
 """
 import yaml
 from lando.exceptions import InvalidConfigException, get_or_raise_config_exception
+import logging
 
 
 class WorkerConfig(object):
@@ -22,6 +23,7 @@ class WorkerConfig(object):
                 raise InvalidConfigException("Empty config file {}.".format(self.filename))
             self.work_queue_config = WorkQueue(data)
             self.cwl_base_command = data.get('cwl_base_command', None)
+            self.log_level = data.get('log_level', logging.WARNING)
 
 
 class WorkQueue(object):

--- a/lando/worker/cwlworkflow.py
+++ b/lando/worker/cwlworkflow.py
@@ -7,6 +7,7 @@ import shutil
 import urllib
 import datetime
 import json
+import logging
 from subprocess import PIPE, Popen
 from lando.exceptions import JobStepFailed
 from lando.worker.cwlreport import create_workflow_info, CwlReport
@@ -174,7 +175,7 @@ class CwlWorkflowProcess(object):
         if not os.path.exists(self.absolute_output_directory):
             os.mkdir(self.absolute_output_directory)
         self.started = datetime.datetime.now()
-        print(self.command)
+        logging.info('Running command: {}'.format(' '.join(self.command)))
         p = Popen(self.command, stderr=PIPE, stdout=PIPE)
         (stdout_data, stderr_data) = p.communicate()
         self.output = stdout_data

--- a/lando/worker/staging.py
+++ b/lando/worker/staging.py
@@ -8,7 +8,7 @@ import requests
 import dateutil.parser
 import logging
 import ddsc.config
-from ddsc.core.remotestore import RemoteStore, RemoteFile
+from ddsc.core.remotestore import RemoteStore, RemoteFile, ProjectNameOrId
 from ddsc.core.download import ProjectDownload
 from ddsc.core.filedownloader import FileDownloader
 from ddsc.core.util import KindType
@@ -91,7 +91,7 @@ class DukeDataService(object):
         :param item: RemoteFile/RemoteFolder: that is being transferrred.
         :param increment_amt: int: allows for progress bar
         """
-        logging.info('Transferring {} of {}', increment_amt, item.name)
+        logging.info('Transferring {} of {}'.format(increment_amt, item.name))
 
     def give_user_permissions(self, project_id, username, auth_role):
         logging.info("give user permissions. project:{} username{}: auth_role:{}".format(project_id, username, auth_role))
@@ -197,7 +197,9 @@ class UploadProject(object):
         :param config: ddsc.config.Config: config settings to use
         :return: ddsc.core.localproject.LocalProject
         """
-        project_upload = ProjectUpload(config, self.project_name, self.file_folder_list)
+        project_upload = ProjectUpload(config,
+                                       ProjectNameOrId.create_from_name(self.project_name),
+                                       self.file_folder_list)
         project_upload.run()
         return project_upload.local_project
 

--- a/lando/worker/staging.py
+++ b/lando/worker/staging.py
@@ -153,7 +153,7 @@ class DownloadDukeDSFile(object):
         """
         create_parent_directory(self.dest)
         duke_data_service = context.get_duke_data_service(self.user_id)
-
+        logging.info("Downloading file id:{} to {}".format(self.file_id, self.dest))
         duke_data_service.download_file(self.file_id, self.dest)
 
 
@@ -175,6 +175,7 @@ class DownloadURLFile(object):
         :param context: Context
         """
         create_parent_directory(self.destination_path)
+        logging.info("Downloading file url:{} to {}".format(self.url, self.destination_path))
         r = requests.get(self.url, stream=True)
         with open(self.destination_path, 'wb') as f:
             for chunk in r.iter_content(chunk_size=DOWNLOAD_URL_CHUNK_SIZE):

--- a/lando/worker/tests/test_config.py
+++ b/lando/worker/tests/test_config.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from unittest import TestCase
 import os
+import logging
 from lando.testutil import write_temp_return_filename
 from lando.worker.config import WorkerConfig
 from lando.exceptions import InvalidConfigException
@@ -30,6 +31,7 @@ class TestWorkerConfig(TestCase):
         self.assertEqual("worker", work_queue_config.username)
         self.assertEqual("workerpass", work_queue_config.password)
         self.assertEqual("task-queue", work_queue_config.queue_name)
+        self.assertEqual(logging.WARNING, config.log_level)
 
     def test_empty_config(self):
         filename = write_temp_return_filename("")
@@ -42,3 +44,9 @@ class TestWorkerConfig(TestCase):
         with self.assertRaises(InvalidConfigException):
             config = WorkerConfig(filename)
         os.unlink(filename)
+
+    def test_log_level(self):
+        filename = write_temp_return_filename('{}\nlog_level: INFO'.format(GOOD_CONFIG))
+        config = WorkerConfig(filename)
+        os.unlink(filename)
+        self.assertEqual('INFO', config.log_level)

--- a/lando/worker/worker.py
+++ b/lando/worker/worker.py
@@ -6,12 +6,11 @@ Run via script with no arguments: lando_worker
 from __future__ import print_function
 import os
 import traceback
-import dateutil.parser
+import logging
 from lando_messaging.clients import LandoClient
 from lando_messaging.messaging import MessageRouter
 from lando.worker import cwlworkflow
 from lando.worker import staging
-from ddsc.core.util import KindType
 
 
 CONFIG_FILE_NAME = '/etc/lando_worker_config.yml'
@@ -144,7 +143,7 @@ class LandoWorker(object):
         """
         router = self._make_router()
         self.client.worker_started(router.queue_name)
-        print("Lando worker listening for messages on queue '{}'.".format(router.queue_name))
+        logging.info("Lando worker listening for messages on queue '{}'.".format(router.queue_name))
         router.run()
 
     def _make_router(self):
@@ -180,20 +179,20 @@ class JobStep(object):
             self.show_complete_message()
         except: # Trap all exceptions
             tb = traceback.format_exc()
-            print("Job failed:{}".format(tb))
+            logging.info("Job failed:{}".format(tb))
             self.send_job_step_errored(tb)
 
     def show_start_message(self):
         """
         Shows message about starting this job step.
         """
-        print("{} started for job {}".format(self.job_description, self.job_id))
+        logging.info("{} started for job {}".format(self.job_description, self.job_id))
 
     def show_complete_message(self):
         """
         Shows message about this job step being completed.
         """
-        print("{} complete for job {}.".format(self.job_description, self.job_id))
+        logging.info("{} complete for job {}.".format(self.job_description, self.job_id))
 
     def send_job_step_errored(self, message):
         """


### PR DESCRIPTION
Allow server and worker config to specify log_level in config file.
The config for both now have an optional top level 'log_level' with the string or int python log level.
The server will write the logging to stdout.
The worker will write logging to `/tmp/lando-worker.log`.

Also fixes a bug in saving the output project for DukeDSClient changes.