### PR TITLE
Include `manage_etc_hosts` in cloud-config script

### DIFF
--- a/lando/server/cloudconfigscript.py
+++ b/lando/server/cloudconfigscript.py
@@ -50,6 +50,16 @@ class CloudConfigScript(object):
         self._add_fs_setup(partition)
         self._add_mount(partition, mount_point)
 
+    def add_manage_etc_hosts(self, value='localhost'):
+        """
+        Adds an entry for manage_etc_hosts
+        The default is 'localhost', which ensures that the /etc/hosts file has an entry
+        resolving the hostname to localhost.
+        :param value: true, false, or 'localhost'
+        :return: None
+        """
+        self._content_dict['manage_etc_hosts'] = value
+
     @staticmethod
     def device_name(partition_name):
         return partition_name.rstrip('1234567890')

--- a/lando/server/lando.py
+++ b/lando/server/lando.py
@@ -139,6 +139,7 @@ class JobActions(object):
         cloud_config_script.add_write_file(content=worker_config_yml, path=WORKER_CONFIG_FILE_NAME)
         for partition, mount_point in self.config.vm_settings.volume_mounts.iteritems():
             cloud_config_script.add_volume(partition, mount_point)
+        cloud_config_script.add_manage_etc_hosts()
         job = self.job_api.get_job()
         cloud_service = self._get_cloud_service(job)
         volume, volume_id = cloud_service.create_volume(job.volume_size, vm_volume_name)

--- a/lando/server/tests/test_cloudconfigscript.py
+++ b/lando/server/tests/test_cloudconfigscript.py
@@ -30,3 +30,11 @@ mounts:
 """
         self.assertMultiLineEqual(expected, c.content)
 
+    def test_manage_etc_hosts(self):
+        c = CloudConfigScript()
+        c.add_manage_etc_hosts()
+        expected = """#cloud-config
+
+{manage_etc_hosts: localhost}
+"""
+        self.assertMultiLineEqual(expected, c.content)

--- a/lando/server/tests/test_lando.py
+++ b/lando/server/tests/test_lando.py
@@ -582,10 +582,13 @@ class TestJobActions(TestCase):
         job_actions.launch_vm('vm1', 'vol1')
 
         name, args, kwargs = mock_cloud_service.launch_instance.mock_calls[0]
-        self.assertEqual(args[0], 'vm1', 'Should call launch_instance with Instance name from launch_vm')
-        self.assertEqual(args[1], 'flavor1', 'Should call launch_instance with flavor from job.vm_flavor')
-        self.assertEqual(args[2], CLOUD_CONFIG)
-        self.assertEqual(args[3], ['vol-id-123'], 'Should call launch_instance with list of vol ids from create_volume')
+
+        mock_cloud_service.launch_instance.assert_called_with(
+            'vm1', # Should call launch_instance with Instance name from launch_vm
+            'flavor1', # Should call launch_instance with flavor from job.vm_flavor
+            CLOUD_CONFIG, # Should generate a cloud config with manage_etc_hosts, fs_setup, and write_files
+            ['vol-id-123'] # Should call launch_instance with list of vol ids from create_volume
+        )
 
         mock_job_api.set_vm_instance_name.assert_called_with('vm1')
         mock_job_api.set_vm_volume_name.assert_called_with('vol1')

--- a/lando/server/tests/test_lando.py
+++ b/lando/server/tests/test_lando.py
@@ -43,6 +43,30 @@ job_api:
 fake_cloud_service: True
 """
 
+LANDO_WORKER_CONFIG = """
+host: 10.109.253.74
+username: worker
+password: workerpass
+queue_name: task-queue
+"""
+
+CLOUD_CONFIG = """#cloud-config
+
+manage_etc_hosts: localhost
+write_files:
+- {content: '
+
+    host: 10.109.253.74
+
+    username: worker
+
+    password: workerpass
+
+    queue_name: task-queue
+
+    ', path: /etc/lando_worker_config.yml}
+"""
+
 
 class Report(object):
     """
@@ -539,3 +563,29 @@ class TestJobActions(TestCase):
         job_actions = JobActions(mock_settings)
         job_actions.cancel_job(MagicMock())
         mock_cloud_service.terminate_instance.assert_not_called()
+
+    def test_launch_vm(self):
+        mock_job = Mock(id='1', state='', step='', cleanup_vm=False, vm_flavor='flavor1')
+        mock_job_api = MagicMock()
+        mock_job_api.get_job.return_value = mock_job
+
+        mock_cloud_service = MagicMock()
+        mock_cloud_service.create_volume = MagicMock(return_value=(MagicMock(), 'vol-id-123',))
+        mock_cloud_service.launch_instance = MagicMock(return_value=(MagicMock(), '1.2.3.4',))
+        mock_settings = MagicMock()
+        mock_settings.get_job_api.return_value = mock_job_api
+        mock_settings.get_cloud_service.return_value = mock_cloud_service
+        mock_make_worker_config_yml = MagicMock()
+        mock_make_worker_config_yml.return_value = LANDO_WORKER_CONFIG
+        mock_settings.config.make_worker_config_yml = mock_make_worker_config_yml
+        job_actions = JobActions(mock_settings)
+        job_actions.launch_vm('vm1', 'vol1')
+
+        name, args, kwargs = mock_cloud_service.launch_instance.mock_calls[0]
+        self.assertEqual(args[0], 'vm1', 'Should call launch_instance with Instance name from launch_vm')
+        self.assertEqual(args[1], 'flavor1', 'Should call launch_instance with flavor from job.vm_flavor')
+        self.assertEqual(args[2], CLOUD_CONFIG)
+        self.assertEqual(args[3], ['vol-id-123'], 'Should call launch_instance with list of vol ids from create_volume')
+
+        mock_job_api.set_vm_instance_name.assert_called_with('vm1')
+        mock_job_api.set_vm_volume_name.assert_called_with('vol1')


### PR DESCRIPTION
Also adds some more comprehensive tests around lando.server.launch_vm

Fixes #79 