### PR TITLE
limit stderr data sent to bespin-api for failed jobs

### DIFF
--- a/lando/worker/cwlworkflow.py
+++ b/lando/worker/cwlworkflow.py
@@ -32,7 +32,7 @@ WORKFLOW_DIRECTORY = 'scripts'
 
 CWL_WORKING_DIRECTORY = 'working'
 
-JOB_STDERR_OUTPUT_MAX_LINES = 5000
+JOB_STDERR_OUTPUT_MAX_LINES = 100
 
 
 def create_dir_if_necessary(path):


### PR DESCRIPTION
Only send the last 5000 lines of stderr to bespin-api for failed jobs.