### PR TITLE
save readme file id to bespin-api job output project

### DIFF
--- a/integration_test/setup.sh
+++ b/integration_test/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-PYTHON=/usr/bin/python
+PYTHON=/usr/local/bin/python
 
 source dds.config
 

--- a/integration_test/setup.sh
+++ b/integration_test/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-PYTHON=/usr/local/bin/python
+PYTHON=/usr/bin/python
 
 source dds.config
 

--- a/lando/server/jobapi.py
+++ b/lando/server/jobapi.py
@@ -227,16 +227,18 @@ class JobApi(object):
         """
         self.api.post_error(self.job_id, job_step, content)
 
-    def save_project_id(self, project_id):
+    def save_project_details(self, project_id, readme_file_id):
         """
-        Update the output directory with the specified project_id.
+        Update the output project with the specified project_id/readme_file_id
         :param project_id: str: uuid of the project
+        :param readme_file_id: str: uuid of the readme file
         """
         job = self.get_job()
         data = {
             'id': job.output_project.id,
             'job': self.job_id,
-            'project_id': project_id
+            'project_id': project_id,
+            'readme_file_id': readme_file_id
         }
         self.api.put_job_output_project(job.output_project.id, data)
 

--- a/lando/server/lando.py
+++ b/lando/server/lando.py
@@ -193,9 +193,10 @@ class JobActions(object):
         :param payload: JobStepCompletePayload: contains job id and vm_instance_name
         """
         self._set_job_step(JobSteps.TERMINATE_VM)
-        project_id = payload.output_project_info
-        self._show_status("Saving project id {}.".format(project_id))
-        self.job_api.save_project_id(project_id)
+        project_id = payload.output_project_info.project_id
+        readme_file_id = payload.output_project_info.readme_file_id
+        self._show_status("Saving project id {} and readme id {}.".format(project_id, readme_file_id))
+        self.job_api.save_project_details(project_id, readme_file_id)
         self._show_status("Terminating VM and queue")
 
         job = self.job_api.get_job()

--- a/lando/server/tests/test_jobapi.py
+++ b/lando/server/tests/test_jobapi.py
@@ -354,6 +354,21 @@ class TestJobApi(TestCase):
         args, kwargs = mock_requests.get.call_args
         self.assertEqual(args[0], 'APIURL/admin/workflow-methods-documents/123')
 
+    @patch('lando.server.jobapi.requests')
+    def test_save_project_details(self, mock_requests):
+        mock_response = MagicMock()
+        mock_response.json.return_value = self.job_response_payload
+        mock_requests.get.return_value = mock_response
+        output_project_id = 5
+        dds_project_id = '123'
+        dds_readme_file_id = '456'
+        job_api = self.setup_job_api(1)
+        job_api.save_project_details(dds_project_id, dds_readme_file_id)
+        mock_requests.put.assert_has_calls([
+            call('APIURL/admin/job-dds-output-projects/{}/'.format(output_project_id), headers={},
+                 json={'readme_file_id': '456', 'job': 1, 'project_id': '123', 'id': output_project_id})
+        ])
+
 
 class TestJob(TestCase):
     def setUp(self):

--- a/lando/server/tests/test_jobapi.py
+++ b/lando/server/tests/test_jobapi.py
@@ -366,7 +366,12 @@ class TestJobApi(TestCase):
         job_api.save_project_details(dds_project_id, dds_readme_file_id)
         mock_requests.put.assert_has_calls([
             call('APIURL/admin/job-dds-output-projects/{}/'.format(output_project_id), headers={},
-                 json={'readme_file_id': '456', 'job': 1, 'project_id': '123', 'id': output_project_id})
+                 json={
+                     'readme_file_id': dds_readme_file_id,
+                     'job': 1,
+                     'project_id': dds_project_id,
+                     'id': output_project_id
+                 })
         ])
 
 

--- a/lando/server/tests/test_lando.py
+++ b/lando/server/tests/test_lando.py
@@ -531,8 +531,10 @@ class TestJobActions(TestCase):
         mock_settings.get_job_api.return_value = mock_job_api
         mock_settings.get_cloud_service.return_value = mock_cloud_service
         job_actions = JobActions(mock_settings)
-        job_actions.store_job_output_complete(MagicMock())
+        mock_output_project_info = Mock(project_id='123', readme_file_id='456')
+        job_actions.store_job_output_complete(MagicMock(output_project_info=mock_output_project_info))
         mock_cloud_service.terminate_instance.assert_called_with('vm1', ['vol1'])
+        mock_job_api.save_project_details.assert_called_with('123', '456')
 
     def test_store_job_output_complete_cleanup_vm_false(self):
         mock_job = Mock(id='1', state='', step='', cleanup_vm=False, vm_instance_name='vm1', vm_volume_name='vol1')

--- a/lando/worker/cwlreport.py
+++ b/lando/worker/cwlreport.py
@@ -61,22 +61,20 @@ class CwlReport(object):
         self.job_data = job_data
         self.template = template
 
-    def render(self):
+    def render_markdown(self):
         """
-        Make the report
+        Return README content in markdown format
         :return: str: report contents
         """
         template = jinja2.Template(self.template)
         return template.render(workflow=self.workflow_info, job=self.job_data)
 
-    def save(self, destination_path):
+    def render_html(self):
         """
-        Save the report to destination_path
-        :param destination_path: str: path to where we will write the report
+        Return README content in html format
+        :return: str: report contents
         """
-        with open(destination_path, 'w') as outfile:
-            html = markdown.markdown(self.render())
-            outfile.write(html.encode('utf8'))
+        return markdown.markdown(self.render_markdown()).encode('utf8')
 
 
 def get_documentation_str(node):

--- a/lando/worker/cwlreport.py
+++ b/lando/worker/cwlreport.py
@@ -47,27 +47,19 @@ You can compare the output from this tool against {{ workflow.job_output_filenam
 """
 
 
-class CwlReport(object):
+class BaseReport(object):
     """
-    Report detailing inputs and outputs of a cwl workflow that has been run.
+    Base report class that assumes subclass will implement render_markdown() that returns markdown format
     """
-    def __init__(self, workflow_info, job_data, template=TEMPLATE):
-        """
-        :param workflow_info: WorkflowInfo: info derived from cwl input/output files
-        :param job_data: dict: data used in report from non-cwl sources
-        :param template: str: template to use for rendering
-        """
-        self.workflow_info = workflow_info
-        self.job_data = job_data
-        self.template = template
+    def __init__(self, template_str):
+        self.template = jinja2.Template(template_str)
 
     def render_markdown(self):
         """
-        Return README content in markdown format
+        This method should be overridden in a subclass
         :return: str: report contents
         """
-        template = jinja2.Template(self.template)
-        return template.render(workflow=self.workflow_info, job=self.job_data)
+        return ''
 
     def render_html(self):
         """
@@ -75,6 +67,28 @@ class CwlReport(object):
         :return: str: report contents
         """
         return markdown.markdown(self.render_markdown()).encode('utf8')
+
+
+class CwlReport(BaseReport):
+    """
+    Report detailing inputs and outputs of a cwl workflow that has been run.
+    """
+    def __init__(self, workflow_info, job_data, template_str=TEMPLATE):
+        """
+        :param workflow_info: WorkflowInfo: info derived from cwl input/output files
+        :param job_data: dict: data used in report from non-cwl sources
+        :param template_str: str: template to use for rendering
+        """
+        super(CwlReport, self).__init__(template_str)
+        self.workflow_info = workflow_info
+        self.job_data = job_data
+
+    def render_markdown(self):
+        """
+        Return README content in markdown format
+        :return: str: report contents
+        """
+        return self.template.render(workflow=self.workflow_info, job=self.job_data)
 
 
 def get_documentation_str(node):

--- a/lando/worker/cwlworkflow.py
+++ b/lando/worker/cwlworkflow.py
@@ -20,7 +20,8 @@ RUN_CWL_OUTDIR_ARG = "--outdir"
 
 RESULTS_DIRECTORY = 'results'
 DOCUMENTATION_DIRECTORY = 'docs'
-README_FILENAME = 'README.html'
+README_MARKDOWN_FILENAME = 'README.md'
+README_HTML_FILENAME = 'README.html'
 
 LOGS_DIRECTORY = 'logs'
 JOB_STDOUT_FILENAME = 'cwltool-output.json'
@@ -297,7 +298,8 @@ class ResultsDirectory(object):
             'workflow_methods': self.workflow_methods_markdown_content
         }
         report = CwlReport(workflow_info, job_data)
-        report.save(os.path.join(self.docs_directory, README_FILENAME))
+        save_data_to_directory(self.docs_directory, README_MARKDOWN_FILENAME, report.render_markdown())
+        save_data_to_directory(self.docs_directory, README_HTML_FILENAME, report.render_html())
         self._save_job_data(job_data)
 
     def _save_job_data(self, job_data):
@@ -310,9 +312,9 @@ class ResultsDirectory(object):
 
     def _create_running_instructions(self):
         workflow_directory = os.path.join(self.docs_directory, WORKFLOW_DIRECTORY)
-        output_filename = os.path.join(workflow_directory, README_FILENAME)
         scripts_readme = ScriptsReadme(self.workflow_basename, self.job_order_filename)
-        scripts_readme.save(output_filename)
+        save_data_to_directory(workflow_directory, README_MARKDOWN_FILENAME, scripts_readme.render_markdown())
+        save_data_to_directory(workflow_directory, README_HTML_FILENAME, scripts_readme.render_html())
 
     def _add_methods_document(self):
         html = markdown.markdown(self.workflow_methods_markdown_content)

--- a/lando/worker/scriptsreadme.py
+++ b/lando/worker/scriptsreadme.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import jinja2
 import markdown
+from lando.worker.cwlreport import BaseReport
 
 TEMPLATE = """
 # Instructions on running this workflow.
@@ -10,26 +11,25 @@ TEMPLATE = """
 """
 
 
-class ScriptsReadme(object):
+class ScriptsReadme(BaseReport):
     """
     Instructions on how to run the workflow in the scripts directory.
     """
-    def __init__(self, workflow_filename, job_order_filename, template=TEMPLATE):
+    def __init__(self, workflow_filename, job_order_filename, template_str=TEMPLATE):
+        """
+        :param workflow_filename: str: name of the cwl workflow a user should run
+        :param job_order_filename: str: name of the job order file a user should include
+        :param template_str: str: template to use for rendering
+        """
+        super(ScriptsReadme, self).__init__(template_str)
         self.workflow_filename = workflow_filename
         self.job_order_filename = job_order_filename
-        self.template = template
 
     def render_markdown(self):
         """
         Make the report
         :return: str: report contents
         """
-        template = jinja2.Template(self.template)
-        return template.render(workflow_filename=self.workflow_filename, job_order_filename=self.job_order_filename)
-
-    def render_html(self):
-        """
-        Return README content in html format
-        :return: str: report contents
-        """
-        return markdown.markdown(self.render_markdown()).encode('utf8')
+        return self.template.render(
+            workflow_filename=self.workflow_filename,
+            job_order_filename=self.job_order_filename)

--- a/lando/worker/scriptsreadme.py
+++ b/lando/worker/scriptsreadme.py
@@ -19,7 +19,7 @@ class ScriptsReadme(object):
         self.job_order_filename = job_order_filename
         self.template = template
 
-    def render(self):
+    def render_markdown(self):
         """
         Make the report
         :return: str: report contents
@@ -27,10 +27,9 @@ class ScriptsReadme(object):
         template = jinja2.Template(self.template)
         return template.render(workflow_filename=self.workflow_filename, job_order_filename=self.job_order_filename)
 
-    def save(self, destination_path):
+    def render_html(self):
         """
-        Save the report to destination_path
-        :param destination_path: str: path to where we will write the report
+        Return README content in html format
+        :return: str: report contents
         """
-        with open(destination_path, 'w') as outfile:
-            outfile.write(markdown.markdown(self.render()).encode('utf8'))
+        return markdown.markdown(self.render_markdown()).encode('utf8')

--- a/lando/worker/staging.py
+++ b/lando/worker/staging.py
@@ -291,15 +291,12 @@ class ProjectDetails(object):
 
     @staticmethod
     def _find_project_file(node, child_names):
-        child_name = child_names.pop()
-        if node.kind in [KindType.project_str, KindType.folder_str]:
-            items = [child for child in node.children if child.name == child_name]
-            if items:
-                return ProjectDetails._find_project_file(items[0], child_names)
-            else:
-                return None
+        if not child_names and node.kind == KindType.file_str:
+            return node.remote_id
         else:
-            if node.name == child_name and not child_names:
-                return node.remote_id
-            return None
-
+            child_name = child_names.pop(0)
+            if node.kind in [KindType.project_str, KindType.folder_str]:
+                items = [child for child in node.children if child.name == child_name]
+                if items:
+                    return ProjectDetails._find_project_file(items[0], child_names)
+        return None

--- a/lando/worker/tests/test_cwlreport.py
+++ b/lando/worker/tests/test_cwlreport.py
@@ -140,17 +140,15 @@ class TestCwlReport(TestCase):
         workflow_info = MagicMock(data='test')
         job_data = MagicMock(job_id=123)
         report = CwlReport(workflow_info, job_data, template)
-        self.assertEqual('test 123', report.render())
+        self.assertEqual('test 123', report.render_markdown())
 
     def test_save_converts_to_html(self):
         template = '{{workflow.data}} {{job.job_id}}'
         workflow_info = MagicMock(data='test')
         job_data = MagicMock(job_id=123)
         report = CwlReport(workflow_info, job_data, template)
-        mocked_open = mock_open(read_data='file contents\nas needed\n')
-        with patch('lando.worker.cwlreport.open', mocked_open):
-            report.save('/tmp/fakedir/fakefile')
-        mocked_open.return_value.write.assert_called_with("<p>test 123</p>")
+        report.render_html()
+        self.assertEqual("<p>test 123</p>", report.render_html())
 
 
 class TestCwlReportUtilities(TestCase):

--- a/lando/worker/tests/test_cwlworkflow.py
+++ b/lando/worker/tests/test_cwlworkflow.py
@@ -219,6 +219,12 @@ class TestResultsDirectory(TestCase):
         cwl_process.finished.isoformat.return_value = ''
         cwl_process.total_runtime_str.return_value = '0 minutes'
 
+        # Specify README data
+        mock_cwl_report.return_value.render_markdown.return_value = '#Markdown'
+        mock_cwl_report.return_value.render_html.return_value = '<html></html>'
+        mock_scripts_readme.return_value.render_markdown.return_value = '#Markdown2'
+        mock_scripts_readme.return_value.render_html.return_value = '<html>2</html>'
+
         # Ask directory to add files based on a mock process
         results_directory.add_files(cwl_process)
         documentation_directory = '/tmp/fakedir/results/docs/'
@@ -230,6 +236,11 @@ class TestResultsDirectory(TestCase):
             call(documentation_directory + 'logs', 'cwltool-output.json', 'stdoutdata'),
             call(documentation_directory + 'logs', 'cwltool-output.log', 'stderrdata'),
             call('/tmp/fakedir/results', 'Methods.html', '<h1>Methods Markdown</h1>'),
+            call('/tmp/fakedir/results/docs', 'README.html', '<html></html>'),
+            call('/tmp/fakedir/results/docs', 'README.md', '#Markdown'),
+            call('/tmp/fakedir/results/docs/scripts', 'README.html', '<html>2</html>'),
+            call('/tmp/fakedir/results/docs/scripts', 'README.md', '#Markdown2'),
+
         ], any_order=True)
         mock_shutil.copy.assert_has_calls([
             call('/tmp/nosuchpath.cwl', documentation_directory + 'scripts/nosuch.cwl'),
@@ -241,10 +252,4 @@ class TestResultsDirectory(TestCase):
             call().update_with_job_output(job_output_path=(documentation_directory + 'logs/cwltool-output.json')),
             call().count_output_files(),
             call().total_file_size_str()
-        ])
-        mock_cwl_report().save.assert_has_calls([
-            call(documentation_directory + 'README.html')
-        ])
-        mock_scripts_readme().save.assert_has_calls([
-            call(documentation_directory + 'scripts/README.html')
         ])

--- a/lando/worker/tests/test_scriptsreadme.py
+++ b/lando/worker/tests/test_scriptsreadme.py
@@ -1,0 +1,15 @@
+from __future__ import absolute_import
+from unittest import TestCase
+from lando.worker.scriptsreadme import ScriptsReadme
+
+
+class TestCwlReport(TestCase):
+    def test_render(self):
+        template = '{{workflow_filename}},{{job_order_filename}}'
+        report = ScriptsReadme('test.cwl', 'test.json', template)
+        self.assertEqual('test.cwl,test.json', report.render_markdown())
+
+    def test_save_converts_to_html(self):
+        template = '{{workflow_filename}},{{job_order_filename}}'
+        report = ScriptsReadme('test.cwl', 'test.json', template)
+        self.assertEqual('<p>test.cwl,test.json</p>', report.render_html())

--- a/lando/worker/tests/test_worker.py
+++ b/lando/worker/tests/test_worker.py
@@ -66,7 +66,8 @@ class FakeObject(object):
         self.report.add("Send job step complete for job {}.".format(payload.job_id))
 
     def job_step_store_output_complete(self, payload, output_project_info):
-        self.report.add("Send job step complete for job {} project:{}.".format(payload.job_id, output_project_info))
+        self.report.add("Send job step complete for job {} project:{}.".format(
+            payload.job_id, output_project_info.project_id))
 
     def run(self, context):
         self.report.add(self.run_message)
@@ -83,6 +84,9 @@ class FakeObject(object):
 
     def get_duke_ds_config(self, user_id):
         return MagicMock()
+
+    def get_details(self):
+        return Mock(project_id='2348', readme_file_id='456')
 
 
 class FakeInputFile(object):

--- a/lando/worker/worker.py
+++ b/lando/worker/worker.py
@@ -105,8 +105,8 @@ class LandoWorkerActions(object):
         """
         source_directory = os.path.join(working_directory, cwlworkflow.CWL_WORKING_DIRECTORY)
         save_job_output = self.settings.make_save_job_output(payload)
-        project = save_job_output.run(source_directory)
-        self.client.job_step_store_output_complete(payload, project.remote_id)
+        save_job_output.run(source_directory)
+        self.client.job_step_store_output_complete(payload, save_job_output.get_details())
 
 
 class LandoWorker(object):


### PR DESCRIPTION
Adds readme file id to PUT request to `job-dds-output-projects/<id>/` that already saves the project id. Also adds markdown README files.
Fixes #78