### PR TITLE
cwltoil temp dir fix

### DIFF
--- a/lando/server/config.py
+++ b/lando/server/config.py
@@ -51,6 +51,7 @@ class ServerConfig(object):
         }
         if not self.fake_cloud_service:
             data['cwl_base_command'] = self.vm_settings.cwl_base_command
+            data['cwl_post_process_command'] = self.vm_settings.cwl_post_process_command
         return yaml.safe_dump(data, default_flow_style=False)
 
 
@@ -79,6 +80,7 @@ class VMSettings(object):
         self.floating_ip_pool_name = get_or_raise_config_exception(data, 'floating_ip_pool_name')
         self.default_flavor_name = get_or_raise_config_exception(data, 'default_flavor_name')
         self.cwl_base_command = data.get("cwl_base_command")
+        self.cwl_post_process_command = data.get("cwl_post_process_command")
         self.volume_mounts = data.get("volume_mounts", {})
 
 

--- a/lando/server/tests/test_config.py
+++ b/lando/server/tests/test_config.py
@@ -101,6 +101,7 @@ class TestServerConfig(TestCase):
         os.unlink(filename)
         expected = """
 cwl_base_command: null
+cwl_post_process_command: null
 host: 10.109.253.74
 password: tobol
 queue_name: worker_1
@@ -110,14 +111,19 @@ username: lobot
         self.assertMultiLineEqual(expected.strip(), result.strip())
 
     def test_make_worker_config_yml_custom_cwl_base_command(self):
-        line = '  cwl_base_command:\n  - "cwltoil"\n  - "--not-strict"'
-        filename = write_temp_return_filename(GOOD_CONFIG.format(line))
+        base_command_line = '  cwl_base_command:\n  - "cwltoil"\n  - "--not-strict"'
+        post_process_command_line = '  cwl_post_process_command:\n  - "rm"\n  - "tmp.data"'
+        lines = '{}\n{}\n'.format(base_command_line, post_process_command_line)
+        filename = write_temp_return_filename(GOOD_CONFIG.format(lines))
         config = ServerConfig(filename)
         os.unlink(filename)
         expected = """
 cwl_base_command:
 - cwltoil
 - --not-strict
+cwl_post_process_command:
+- rm
+- tmp.data
 host: 10.109.253.74
 password: tobol
 queue_name: worker_1

--- a/lando/worker/config.py
+++ b/lando/worker/config.py
@@ -23,6 +23,7 @@ class WorkerConfig(object):
                 raise InvalidConfigException("Empty config file {}.".format(self.filename))
             self.work_queue_config = WorkQueue(data)
             self.cwl_base_command = data.get('cwl_base_command', None)
+            self.cwl_post_process_command = data.get('cwl_post_process_command', None)
             self.log_level = data.get('log_level', logging.WARNING)
 
 

--- a/lando/worker/tests/test_config.py
+++ b/lando/worker/tests/test_config.py
@@ -11,6 +11,11 @@ host: 10.109.253.74
 username: worker
 password: workerpass
 queue_name: task-queue
+cwl_base_command: 
+- cwltoil
+cwl_post_process_command: 
+- rm 
+- bad.data
 """
 
 # missing queuename field
@@ -31,6 +36,8 @@ class TestWorkerConfig(TestCase):
         self.assertEqual("worker", work_queue_config.username)
         self.assertEqual("workerpass", work_queue_config.password)
         self.assertEqual("task-queue", work_queue_config.queue_name)
+        self.assertEqual(["cwltoil"], config.cwl_base_command)
+        self.assertEqual(['rm', 'bad.data'], config.cwl_post_process_command)
         self.assertEqual(logging.WARNING, config.log_level)
 
     def test_empty_config(self):

--- a/lando/worker/tests/test_cwlworkflow.py
+++ b/lando/worker/tests/test_cwlworkflow.py
@@ -56,6 +56,7 @@ class TestCwlWorkflow(TestCase):
         job_id = 1
         working_directory = tempfile.mkdtemp()
         cwl_base_command = None
+        cwl_post_process_command = None
         workflow_directory = tempfile.mkdtemp()
         cwl_path = os.path.join(workflow_directory, 'workflow.cwl')
         text_to_file(SAMPLE_WORKFLOW, cwl_path)
@@ -75,6 +76,7 @@ outputfile: results.txt
         workflow = CwlWorkflow(job_id,
                                working_directory,
                                cwl_base_command,
+                               cwl_post_process_command,
                                '# Workflow Methods Markdown')
         workflow.run(cwl_file_url, workflow_object_name, job_order)
         shutil.rmtree(workflow_directory)
@@ -94,6 +96,7 @@ outputfile: results.txt
         job_id = 1
         working_directory = tempfile.mkdtemp()
         cwl_base_command = None
+        cwl_post_process_command = None
         workflow_directory = tempfile.mkdtemp()
         cwl_path = os.path.join(workflow_directory, 'workflow.cwl')
         text_to_file(SAMPLE_WORKFLOW, cwl_path)
@@ -115,6 +118,7 @@ outputfile: results.txt
         workflow = CwlWorkflow(job_id,
                                working_directory,
                                cwl_base_command,
+                               cwl_post_process_command,
                                "# markdown")
         with self.assertRaises(JobStepFailed):
             workflow.run(cwl_file_url, workflow_object_name, job_order)
@@ -133,10 +137,11 @@ outputfile: results.txt
         job_id = '123'
         working_directory = '/tmp/job_123'
         cwl_base_command = 'cwl-runner'
+        cwl_post_process_command = None
         cwl_file_url = 'file://packed.cwl'
         workflow_object_name = '#main'
         job_order = {}
-        workflow = CwlWorkflow(job_id, working_directory, cwl_base_command, "# markdown")
+        workflow = CwlWorkflow(job_id, working_directory, cwl_base_command, cwl_post_process_command, "# markdown")
         self.assertEqual(workflow.max_stderr_output_lines, JOB_STDERR_OUTPUT_MAX_LINES)
         workflow.max_stderr_output_lines = 3
         with self.assertRaises(JobStepFailed) as raised_error:

--- a/lando/worker/tests/test_worker.py
+++ b/lando/worker/tests/test_worker.py
@@ -46,7 +46,9 @@ class FakeSettings(object):
     def make_download_url_file(self, url, destination_path):
         return FakeObject("Download url {}.".format(url), self.report)
 
-    def make_cwl_workflow(self, job_id, working_directory, cwl_base_command, workflow_methods_markdown):
+    def make_cwl_workflow(self, job_id, working_directory,
+                          cwl_base_command, cwl_post_process_command,
+                          workflow_methods_markdown):
         if self.raise_when_run_workflow:
             raise ValueError("Something went wrong.")
         obj = FakeObject("Run workflow for job {}.".format(job_id), self.report)

--- a/lando/worker/worker.py
+++ b/lando/worker/worker.py
@@ -41,8 +41,10 @@ class LandoWorkerSettings(object):
         return staging.DownloadURLFile(url, destination_path)
 
     @staticmethod
-    def make_cwl_workflow(job_id, working_directory, cwl_base_command, workflow_methods_markdown):
-        return cwlworkflow.CwlWorkflow(job_id, working_directory, cwl_base_command, workflow_methods_markdown)
+    def make_cwl_workflow(job_id, working_directory, cwl_base_command, cwl_post_process_command,
+                          workflow_methods_markdown):
+        return cwlworkflow.CwlWorkflow(job_id, working_directory, cwl_base_command, cwl_post_process_command,
+                                       workflow_methods_markdown)
 
     @staticmethod
     def make_upload_project(project_name, file_folder_list):
@@ -91,9 +93,11 @@ class LandoWorkerActions(object):
         :param payload: router.RunJobPayload: details about workflow to run
         """
         cwl_base_command = self.config.cwl_base_command
+        cwl_post_process_command = self.config.cwl_post_process_command
         workflow_methods_markdown = payload.job_details.workflow_methods_document.content
         workflow = self.settings.make_cwl_workflow(payload.job_id, working_directory,
-                                                   cwl_base_command, workflow_methods_markdown)
+                                                   cwl_base_command, cwl_post_process_command,
+                                                   workflow_methods_markdown)
         workflow.run(payload.cwl_file_url, payload.workflow_object_name, payload.job_order)
         self.client.job_step_complete(payload)
 


### PR DESCRIPTION
Adds `cwl_post_process_command` array option to the lando server configuration.
This option is sent to the worker's config. The command is run once the CWL workflow succeeds and the output directory tree is created. The `cwl_post_process_command` will execute from within the `results` directory. After `cwl_post_process_command` is run the directory will be uploaded to DukeDS in the next step.