### PR TITLE
Fix render unicode

### DIFF
--- a/lando/worker/cwlreport.py
+++ b/lando/worker/cwlreport.py
@@ -8,6 +8,7 @@ import yaml
 import jinja2
 import humanfriendly
 import markdown
+import codecs
 
 TEMPLATE = """
 # Summary
@@ -288,7 +289,7 @@ def parse_yaml_or_json(path):
     """
     Return parsed YAML or JSON for a path to a file.
     """
-    with open(path) as infile:
+    with codecs.open(path, mode='r', encoding='utf-8') as infile:
         doc = yaml.load(infile)
     return doc
 

--- a/lando/worker/cwlreport.py
+++ b/lando/worker/cwlreport.py
@@ -66,7 +66,7 @@ class BaseReport(object):
         Return README content in html format
         :return: str: report contents
         """
-        return markdown.markdown(self.render_markdown()).encode('utf8')
+        return markdown.markdown(self.render_markdown())
 
 
 class CwlReport(BaseReport):

--- a/lando/worker/cwlworkflow.py
+++ b/lando/worker/cwlworkflow.py
@@ -10,6 +10,7 @@ import json
 import markdown
 import logging
 import subprocess
+import codecs
 from lando.exceptions import JobStepFailed
 from lando.worker.cwlreport import create_workflow_info, CwlReport
 from lando.worker.scriptsreadme import ScriptsReadme
@@ -54,8 +55,8 @@ def save_data_to_directory(directory_path, filename, data):
     :return: str: directory_path/filename
     """
     file_path = os.path.join(directory_path, filename)
-    with open(file_path, 'w') as outfile:
-        outfile.write(data.encode('utf8'))
+    with codecs.open(file_path, 'w', encoding='utf-8', errors='xmlcharrefreplace') as outfile:
+        outfile.write(data)
     return file_path
 
 

--- a/lando/worker/tests/test_cwlreport.py
+++ b/lando/worker/tests/test_cwlreport.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import absolute_import
 from unittest import TestCase
 from lando.worker.cwlreport import CwlReport, get_documentation_str, create_workflow_info
@@ -177,6 +179,14 @@ class TestCwlReport(TestCase):
         report = CwlReport(workflow_info, job_data, template)
         report.render_html()
         self.assertEqual("<p>test 123</p>", report.render_html())
+
+    def test_handles_unicode(self):
+        template = u'{{workflow.data}}qüü{{job.job_id}}'
+        workflow_info = MagicMock(data=u'ää')
+        job_data = MagicMock(job_id=u'üä')
+        report = CwlReport(workflow_info, job_data, template)
+        rendered = report.render_html()
+        self.assertEqual(u'<p>ääqüüüä</p>', rendered)
 
 
 class TestCwlReportUtilities(TestCase):


### PR DESCRIPTION
Use codecs.open to read/write files for marking encoding to markdown rendering

Fixes #98 