### PR TITLE
server: read vm_settings per Job rather than global config

### DIFF
--- a/lando/server/cloudservice.py
+++ b/lando/server/cloudservice.py
@@ -71,7 +71,7 @@ class CloudService(object):
         :param config: Config config settings for vm and credentials
         :param vm_settings: VMSettings object with vm_project_name, image_name, network and IP settings
         """
-        self.cloud_client = CloudClient(config.cloud_settings.credentials(vm_settings.project_name))
+        self.cloud_client = CloudClient(config.cloud_settings.credentials(vm_settings.vm_project_name))
         self.vm_settings = vm_settings
 
     def launch_instance(self, server_name, flavor_name, script_contents, volumes):

--- a/lando/server/cloudservice.py
+++ b/lando/server/cloudservice.py
@@ -29,7 +29,7 @@ class CloudClient(object):
         """
         instance = self.cloud.create_server(
             name=server_name,
-            image=vm_settings.worker_image_name,
+            image=vm_settings.image_name,
             flavor=vm_flavor_name,    # The flavor 'Root Disk' value has no effect due to using a volume for storage
             key_name=vm_settings.ssh_key_name,
             network=vm_settings.network_name,

--- a/lando/server/config.py
+++ b/lando/server/config.py
@@ -50,8 +50,8 @@ class ServerConfig(object):
         }
         if not self.fake_cloud_service:
             data['cwl_base_command'] = cwl_command.base_command
-            data['cwl_pre_process_command'] = cwl_command.pre_process_command
             data['cwl_post_process_command'] = cwl_command.post_process_command
+            data['cwl_pre_process_command'] = cwl_command.pre_process_command
         return yaml.safe_dump(data, default_flow_style=False)
 
 

--- a/lando/server/config.py
+++ b/lando/server/config.py
@@ -10,7 +10,7 @@ import logging
 class ServerConfig(object):
     """
     Configuration for either Server or Client.
-    For worker vm_settings and cloud_settings will return None.
+    For worker, cloud_settings will return None.
     """
     def __init__(self, filename):
         """

--- a/lando/server/config.py
+++ b/lando/server/config.py
@@ -23,7 +23,6 @@ class ServerConfig(object):
                 raise InvalidConfigException("Empty config file {}.".format(filename))
             self.fake_cloud_service = data.get('fake_cloud_service', False)
             self.work_queue_config = WorkQueue(get_or_raise_config_exception(data, 'work_queue'))
-            self.vm_settings = self._optional_get(data, 'vm_settings', VMSettings)
             self.cloud_settings = self._optional_get(data, 'cloud_settings', CloudSettings)
             self.bespin_api_settings = self._optional_get(data, 'bespin_api', BespinApiSettings)
             self.log_level = data.get('log_level', logging.WARNING)
@@ -36,7 +35,7 @@ class ServerConfig(object):
         else:
             return None
 
-    def make_worker_config_yml(self, queue_name):
+    def make_worker_config_yml(self, queue_name, cwl_command):
         """
         Create a worker config file that can be sent to a worker VM so they can respond to messages on queue_name.
         :param queue_name: str: name of the queue the worker will listen on.
@@ -50,8 +49,9 @@ class ServerConfig(object):
             'queue_name': queue_name
         }
         if not self.fake_cloud_service:
-            data['cwl_base_command'] = self.vm_settings.cwl_base_command
-            data['cwl_post_process_command'] = self.vm_settings.cwl_post_process_command
+            data['cwl_base_command'] = cwl_command.base_command
+            data['cwl_pre_process_command'] = cwl_command.pre_process_command
+            data['cwl_post_process_command'] = cwl_command.post_process_command
         return yaml.safe_dump(data, default_flow_style=False)
 
 
@@ -66,22 +66,6 @@ class WorkQueue(object):
         self.worker_username = get_or_raise_config_exception(data, 'worker_username')
         self.worker_password = get_or_raise_config_exception(data, 'worker_password')
         self.listen_queue = get_or_raise_config_exception(data, 'listen_queue')
-
-
-class VMSettings(object):
-    """
-    Settings used to create a VM for running a job on.
-    """
-    def __init__(self, data):
-        self.worker_image_name = get_or_raise_config_exception(data, 'worker_image_name')
-        self.ssh_key_name = get_or_raise_config_exception(data, 'ssh_key_name')
-        self.network_name = get_or_raise_config_exception(data, 'network_name')
-        self.allocate_floating_ips = data.get('allocate_floating_ips', False)
-        self.floating_ip_pool_name = get_or_raise_config_exception(data, 'floating_ip_pool_name')
-        self.default_flavor_name = get_or_raise_config_exception(data, 'default_flavor_name')
-        self.cwl_base_command = data.get("cwl_base_command")
-        self.cwl_post_process_command = data.get("cwl_post_process_command")
-        self.volume_mounts = data.get("volume_mounts", {})
 
 
 class CloudSettings(object):

--- a/lando/server/jobapi.py
+++ b/lando/server/jobapi.py
@@ -480,10 +480,13 @@ class VMSettings(object):
     Contains openstack details for launching VMs
     """
     def __init__(self, data):
-        self.vm_project_name = data['cloud_settings']['vm_project']['name']
-        self.ssh_key_name = data['ssh_key_name']
-        self.network_name = data['network_name']
-        self.allocate_floating_ips = data['allocate_floating_ips']
-        self.floating_ip_pool_name = data['floating_ip_pool_name']
+        # These come from the nested cloud_settings
+        cloud_settings = data['cloud_settings']
+        self.vm_project_name = cloud_settings['vm_project']['name']
+        self.ssh_key_name = cloud_settings['ssh_key_name']
+        self.network_name = cloud_settings['network_name']
+        self.allocate_floating_ips = cloud_settings['allocate_floating_ips']
+        self.floating_ip_pool_name = cloud_settings['floating_ip_pool_name']
+        # These are in the data dictionary directly
         self.image_name = data['image_name']
         self.cwl_command = CWLCommand(data)

--- a/lando/server/jobapi.py
+++ b/lando/server/jobapi.py
@@ -489,4 +489,4 @@ class VMSettings(object):
         self.floating_ip_pool_name = cloud_settings['floating_ip_pool_name']
         # These are in the data dictionary directly
         self.image_name = data['image_name']
-        self.cwl_command = CWLCommand(data)
+        self.cwl_commands = CWLCommand(data)

--- a/lando/server/jobapi.py
+++ b/lando/server/jobapi.py
@@ -3,7 +3,7 @@ Allows reading and updating job information when talking to Bespin REST api.
 """
 from __future__ import print_function
 import requests
-
+import json
 
 class BespinApi(object):
     """
@@ -301,15 +301,17 @@ class Job(object):
         self.name = data['name']
         self.state = data['state']
         self.step = data['step']
-        self.vm_flavor = data['vm_flavor']
+        self.vm_flavor_name = data['vm_flavor']['name']
         self.vm_instance_name = data['vm_instance_name']
         self.vm_volume_name = data['vm_volume_name']
-        self.vm_project_name = data['vm_project_name']
         self.stage_group = data['stage_group']
         self.workflow = Workflow(data)
         self.output_project = OutputProject(data)
         self.volume_size = data['volume_size']
+        # Volume mounts is JSON encoded in a text field
+        self.volume_mounts = json.loads(data['volume_mounts'])
         self.cleanup_vm = data.get('cleanup_vm', True)
+        self.vm_settings = VMSettings(data)
 
 
 class RunJobData(Job):
@@ -454,3 +456,34 @@ class JobSteps(object):
     STORING_JOB_OUTPUT = 'O'
     TERMINATE_VM = 'T'
 
+
+class CWLCommand(object):
+    """
+    Stores CWL commands to pass to the worker
+    """
+
+    def __init__(self, data):
+        """
+        Loads JSON-encoded CWL commands from dictionary
+        :param data:
+        """
+        self.base_command = json.loads(data.get('cwl_base_command'))
+        self.pre_process_command = json.loads(data.get('cwl_pre_process_command','[]'))
+        self.post_process_command = json.loads(data.get('cwl_post_process_command','[]'))
+
+    def __str__(self):
+        return self.base_command
+
+
+class VMSettings(object):
+    """
+    Contains openstack details for launching VMs
+    """
+    def __init__(self, data):
+        self.vm_project_name = data['cloud_settings']['vm_project']['name']
+        self.ssh_key_name = data['ssh_key_name']
+        self.network_name = data['network_name']
+        self.allocate_floating_ips = data['allocate_floating_ips']
+        self.floating_ip_pool_name = data['floating_ip_pool_name']
+        self.image_name = data['image_name']
+        self.cwl_command = CWLCommand(data)

--- a/lando/server/jobapi.py
+++ b/lando/server/jobapi.py
@@ -309,9 +309,9 @@ class Job(object):
         self.output_project = OutputProject(data)
         self.volume_size = data['volume_size']
         # Volume mounts is JSON encoded in a text field
-        self.volume_mounts = json.loads(data['volume_mounts'])
+        self.volume_mounts = json.loads(data['vm_volume_mounts'])
         self.cleanup_vm = data.get('cleanup_vm', True)
-        self.vm_settings = VMSettings(data)
+        self.vm_settings = VMSettings(data.get('vm_settings'))
 
 
 class RunJobData(Job):

--- a/lando/server/lando.py
+++ b/lando/server/lando.py
@@ -275,7 +275,7 @@ class JobActions(object):
         self.work_progress_queue.send(payload)
 
     def _get_cloud_service(self, job):
-        return self.settings.get_cloud_service(job.vm_project_name)
+        return self.settings.get_cloud_service(job.vm_settings)
 
     def _show_status(self, message):
         format_str = "{}: {} for job: {}."

--- a/lando/server/lando.py
+++ b/lando/server/lando.py
@@ -134,13 +134,13 @@ class JobActions(object):
         """
         self._set_job_step(JobSteps.CREATE_VM)
         self._show_status("Creating VM")
-        worker_config_yml = self.config.make_worker_config_yml(vm_instance_name)
+        job = self.job_api.get_job()
+        worker_config_yml = self.config.make_worker_config_yml(vm_instance_name, job.vm_settings.cwl_commands)
         cloud_config_script = CloudConfigScript()
         cloud_config_script.add_write_file(content=worker_config_yml, path=WORKER_CONFIG_FILE_NAME)
-        for partition, mount_point in self.config.vm_settings.volume_mounts.iteritems():
+        for partition, mount_point in job.vm_settings.volume_mounts.iteritems():
             cloud_config_script.add_volume(partition, mount_point)
         cloud_config_script.add_manage_etc_hosts()
-        job = self.job_api.get_job()
         cloud_service = self._get_cloud_service(job)
         volume, volume_id = cloud_service.create_volume(job.volume_size, vm_volume_name)
         instance, ip_address = cloud_service.launch_instance(vm_instance_name, job.vm_flavor, cloud_config_script.content,

--- a/lando/server/lando.py
+++ b/lando/server/lando.py
@@ -143,7 +143,7 @@ class JobActions(object):
         cloud_config_script.add_manage_etc_hosts()
         cloud_service = self._get_cloud_service(job)
         volume, volume_id = cloud_service.create_volume(job.volume_size, vm_volume_name)
-        instance, ip_address = cloud_service.launch_instance(vm_instance_name, job.vm_flavor, cloud_config_script.content,
+        instance, ip_address = cloud_service.launch_instance(vm_instance_name, job.vm_flavor_name, cloud_config_script.content,
                                                              [volume_id])
         self._show_status("Launched vm with ip {}".format(ip_address))
         self.job_api.set_vm_instance_name(vm_instance_name)

--- a/lando/server/lando.py
+++ b/lando/server/lando.py
@@ -32,7 +32,7 @@ class JobSettings(object):
         self.job_id = job_id
         self.config = config
 
-    def get_cloud_service(self, project_name):
+    def get_cloud_service(self, vm_settings):
         """
         Creates cloud service for creating and deleting VMs.
         If configuration has fake_cloud_service set to True this will create a fake cloud service for debugging purposes.
@@ -42,7 +42,7 @@ class JobSettings(object):
         if self.config.fake_cloud_service:
             return FakeCloudService(self.config)
         else:
-            return CloudService(self.config, project_name)
+            return CloudService(self.config, vm_settings)
 
     def get_job_api(self):
         """

--- a/lando/server/lando.py
+++ b/lando/server/lando.py
@@ -138,7 +138,7 @@ class JobActions(object):
         worker_config_yml = self.config.make_worker_config_yml(vm_instance_name, job.vm_settings.cwl_commands)
         cloud_config_script = CloudConfigScript()
         cloud_config_script.add_write_file(content=worker_config_yml, path=WORKER_CONFIG_FILE_NAME)
-        for partition, mount_point in job.vm_settings.volume_mounts.iteritems():
+        for partition, mount_point in job.volume_mounts.iteritems():
             cloud_config_script.add_volume(partition, mount_point)
         cloud_config_script.add_manage_etc_hosts()
         cloud_service = self._get_cloud_service(job)

--- a/lando/server/tests/test_cloudservice.py
+++ b/lando/server/tests/test_cloudservice.py
@@ -36,7 +36,7 @@ class TestCloudService(TestCase):
     @mock.patch('lando.server.cloudservice.shade')
     def test_launch_instance_no_floating_ip(self, mock_shade):
         mock_shade.openstack_cloud().create_server.return_value = mock.Mock(accessIPv4='')
-        config = mock.MagicMock(vm_settings=mock.Mock(worker_image_name='myvm', floating_ip_pool_name='somepool'))
+        config = mock.MagicMock(vm_settings=mock.Mock(image_name='myvm', floating_ip_pool_name='somepool'))
         vm_settings = mock.MagicMock(allocate_floating_ips=False)
         cloud_service = CloudService(config, vm_settings)
         instance, ip_address = cloud_service.launch_instance(server_name="worker1", flavor_name=None,

--- a/lando/server/tests/test_cloudservice.py
+++ b/lando/server/tests/test_cloudservice.py
@@ -5,6 +5,22 @@ import mock
 
 
 class TestCloudService(TestCase):
+    @mock.patch('lando.server.cloudservice.CloudClient')
+    def test_makes_cloud_client(self, mock_cloud_client):
+        mock_credentials = mock.Mock() # a function that returns credentials
+        config = mock.MagicMock(cloud_settings=mock.MagicMock(credentials=mock_credentials))
+        vm_settings = mock.MagicMock(vm_project_name='test-project')
+        service = CloudService(config, vm_settings)
+        self.assertEqual(service.vm_settings, vm_settings)
+
+        # Assert that mock_credentials was called with the vm_project_name
+        args, kwargs = mock_credentials.call_args
+        self.assertEqual(args[0], 'test-project')
+
+        # Assert that CloudClient is called with the return value of credentials
+        args, kwargs = mock_cloud_client.call_args
+        self.assertEqual(args[0], mock_credentials.return_value)
+
     @mock.patch('lando.server.cloudservice.shade')
     def test_that_flavor_overrides_default(self, mock_shade):
         config = mock.MagicMock()

--- a/lando/server/tests/test_cloudservice.py
+++ b/lando/server/tests/test_cloudservice.py
@@ -8,8 +8,8 @@ class TestCloudService(TestCase):
     @mock.patch('lando.server.cloudservice.shade')
     def test_that_flavor_overrides_default(self, mock_shade):
         config = mock.MagicMock()
-        config.vm_settings.default_flavor_name = 'm1.xbig'
-        cloud_service = CloudService(config, project_name='bespin_user1')
+        vm_settings = mock.MagicMock()
+        cloud_service = CloudService(config, vm_settings)
         cloud_service.launch_instance(server_name="worker1", flavor_name='m1.GIANT', script_contents="",
                                       volumes=['volume1'])
         mock_shade.openstack_cloud()
@@ -18,23 +18,11 @@ class TestCloudService(TestCase):
         self.assertEqual(kw_args['flavor'], 'm1.GIANT')
 
     @mock.patch('lando.server.cloudservice.shade')
-    def test_that_no_flavor_chooses_default(self, mock_shade):
-        config = mock.MagicMock()
-        config.vm_settings.default_flavor_name = 'm1.xbig'
-        cloud_service = CloudService(config, project_name='bespin_user1')
-        cloud_service.launch_instance(server_name="worker1", flavor_name=None, script_contents="",volumes=['volume1'])
-        mock_shade.openstack_cloud().create_server.assert_called()
-        args, kw_args = mock_shade.openstack_cloud().create_server.call_args
-        self.assertEqual(kw_args['flavor'], 'm1.xbig')
-        self.assertEqual(kw_args['volumes'], ['volume1'])
-
-    @mock.patch('lando.server.cloudservice.shade')
     def test_launch_instance_no_floating_ip(self, mock_shade):
         mock_shade.openstack_cloud().create_server.return_value = mock.Mock(accessIPv4='')
         config = mock.MagicMock(vm_settings=mock.Mock(worker_image_name='myvm', floating_ip_pool_name='somepool'))
-        config.vm_settings.allocate_floating_ips = False
-        config.vm_settings.default_flavor_name = 'm1.large'
-        cloud_service = CloudService(config, project_name='bespin_user1')
+        vm_settings = mock.MagicMock(allocate_floating_ips=False)
+        cloud_service = CloudService(config, vm_settings)
         instance, ip_address = cloud_service.launch_instance(server_name="worker1", flavor_name=None,
                                                              script_contents="", volumes=['volume1'])
         self.assertEqual('', ip_address)
@@ -47,10 +35,9 @@ class TestCloudService(TestCase):
     def test_launch_instance_with_floating_ip(self, mock_shade):
         mock_shade.openstack_cloud().create_server.return_value = mock.Mock(accessIPv4='123')
         config = mock.MagicMock()
-        config.vm_settings.allocate_floating_ips = True
-        config.vm_settings.default_flavor_name = 'm1.large'
-        cloud_service = CloudService(config, project_name='bespin_user1')
-        instance, ip_address = cloud_service.launch_instance(server_name="worker1", flavor_name=None,
+        vm_settings = mock.MagicMock(allocate_floating_ips=True)
+        cloud_service = CloudService(config, vm_settings)
+        instance, ip_address = cloud_service.launch_instance(server_name="worker1", flavor_name='flavor1',
                                                              script_contents="", volumes=['volume1'])
         self.assertNotEqual(None, ip_address)
         mock_shade.openstack_cloud().create_server.assert_called()
@@ -60,9 +47,8 @@ class TestCloudService(TestCase):
     @mock.patch('lando.server.cloudservice.shade')
     def test_terminate_instance_no_floating_ip(self, mock_shade):
         config = mock.MagicMock()
-        config.vm_settings.allocate_floating_ips = False
-        config.vm_settings.default_flavor_name = 'm1.large'
-        cloud_service = CloudService(config, project_name='bespin_user1')
+        vm_settings = mock.MagicMock(allocate_floating_ips=False)
+        cloud_service = CloudService(config, vm_settings)
         cloud_service.terminate_instance(server_name='worker1', volume_names=[])
         mock_shade.openstack_cloud().delete_server.assert_called()
         args, kw_args = mock_shade.openstack_cloud().delete_server.call_args
@@ -71,9 +57,8 @@ class TestCloudService(TestCase):
     @mock.patch('lando.server.cloudservice.shade')
     def test_terminate_instance_with_floating_ip(self, mock_shade):
         config = mock.MagicMock()
-        config.vm_settings.allocate_floating_ips = True
-        config.vm_settings.default_flavor_name = 'm1.large'
-        cloud_service = CloudService(config, project_name='bespin_user1')
+        vm_settings = mock.MagicMock(allocate_floating_ips=True)
+        cloud_service = CloudService(config, vm_settings)
         cloud_service.terminate_instance(server_name='worker1')
         args, kw_args = mock_shade.openstack_cloud().delete_server.call_args
         self.assertEqual(kw_args['delete_ips'], True)
@@ -82,7 +67,8 @@ class TestCloudService(TestCase):
     def test_create_volume(self, mock_shade):
         mock_shade.openstack_cloud().create_volume.return_value = mock.Mock(id='volume-id1')
         config = mock.MagicMock()
-        cloud_service = CloudService(config, project_name='bespin_user1')
+        vm_settings = mock.MagicMock()
+        cloud_service = CloudService(config, vm_settings)
         volume, volume_id = cloud_service.create_volume(100, 'volume1')
         self.assertIsNotNone(volume_id)
         mock_shade.openstack_cloud().create_volume.assert_called()
@@ -93,8 +79,8 @@ class TestCloudService(TestCase):
     @mock.patch('lando.server.cloudservice.shade')
     def test_terminate_instance_with_volumes(self, mock_shade):
         config = mock.MagicMock()
-        config.vm_settings.default_flavor_name = 'm1.large'
-        cloud_service = CloudService(config, project_name='bespin_user1')
+        vm_settings = mock.MagicMock()
+        cloud_service = CloudService(config, vm_settings)
         cloud_service.terminate_instance(server_name='worker1', volume_names=['volume1'])
         args, kw_args = mock_shade.openstack_cloud().delete_server.call_args
         self.assertEqual(args, ('worker1',))
@@ -108,7 +94,8 @@ class TestCloudService(TestCase):
     def test_make_volume_name(self, mock_uuid, mock_shade):
         mock_uuid.uuid4 = mock.Mock(return_value='uuid-1234')
         config = mock.MagicMock()
-        cloud_service = CloudService(config, project_name='bespin_user1')
+        vm_settings = mock.MagicMock()
+        cloud_service = CloudService(config, vm_settings)
         volume_name = cloud_service.make_volume_name('6')
         self.assertEqual(volume_name, 'vol-job6_uuid-1234')
         self.assertTrue(mock_uuid.uuid4.called)

--- a/lando/server/tests/test_jobapi.py
+++ b/lando/server/tests/test_jobapi.py
@@ -486,6 +486,6 @@ class VMSettingsTests(TestCase):
         self.assertEqual(vm_settings.allocate_floating_ips, True)
         self.assertEqual(vm_settings.floating_ip_pool_name, 'test_pool_name')
         self.assertEqual(vm_settings.image_name, 'test_image')
-        self.assertEqual(vm_settings.cwl_command, loaded_cwl_command)
+        self.assertEqual(vm_settings.cwl_commands, loaded_cwl_command)
         args, kwargs = mock_cwl_command.call_args
         self.assertEqual(args[0], self.data)

--- a/lando/server/tests/test_jobapi.py
+++ b/lando/server/tests/test_jobapi.py
@@ -463,11 +463,15 @@ class VMSettingsTests(TestCase):
 
     def setUp(self):
         self.data = {
-            "cloud_settings": { "vm_project": { "name": "test_project" } },
-            "ssh_key_name": "test_ssh_key",
-            "network_name": "test_network",
-            "allocate_floating_ips": True,
-            "floating_ip_pool_name": "test_pool_name",
+            "cloud_settings": {
+                "vm_project": {
+                    "name": "test_project"
+                },
+                "ssh_key_name": "test_ssh_key",
+                "network_name": "test_network",
+                "allocate_floating_ips": True,
+                "floating_ip_pool_name": "test_pool_name",
+            },
             "image_name": "test_image",
         }
 

--- a/lando/server/tests/test_lando.py
+++ b/lando/server/tests/test_lando.py
@@ -20,13 +20,6 @@ work_queue:
   worker_password: tobol
   listen_queue: lando
 
-vm_settings:
-  worker_image_name: lando_worker
-  ssh_key_name: jpb67
-  network_name: selfservice
-  floating_ip_pool_name: ext-net
-  default_flavor_name: m1.small
-
 cloud_settings:
   auth_url: http://10.109.252.9:5000/v3
   username: jpb67
@@ -573,7 +566,9 @@ class TestJobActions(TestCase):
         mock_cloud_service.terminate_instance.assert_not_called()
 
     def test_launch_vm(self):
-        mock_job = Mock(id='1', state='', step='', cleanup_vm=False, vm_flavor='flavor1')
+        mock_vm_settings = Mock(cwl_commands=None)
+        mock_job = Mock(id='1', state='', step='', cleanup_vm=False, vm_flavor_name='flavor1',
+                        volume_mounts={'/dev/vdb1':'/work'}, vm_settings=mock_vm_settings)
         mock_job_api = MagicMock()
         mock_job_api.get_job.return_value = mock_job
 
@@ -586,7 +581,6 @@ class TestJobActions(TestCase):
         mock_make_worker_config_yml = MagicMock()
         mock_make_worker_config_yml.return_value = LANDO_WORKER_CONFIG
         mock_settings.config.make_worker_config_yml = mock_make_worker_config_yml
-        mock_settings.config.vm_settings.volume_mounts = {'/dev/vdb1':'/work'}
         job_actions = JobActions(mock_settings)
         job_actions.launch_vm('vm1', 'vol1')
 

--- a/lando/server/tests/test_lando.py
+++ b/lando/server/tests/test_lando.py
@@ -124,7 +124,7 @@ class Report(object):
         job.user_id = '1'
         job.state = self.job_state
         job.step = self.job_step
-        job.vm_flavor = ''
+        job.vm_flavor_name = ''
         job.vm_instance_name = self.vm_instance_name
         job.vm_volume_name = self.vm_volume_name
         job.vm_project_name = 'bespin_user1'
@@ -596,7 +596,7 @@ class TestJobActions(TestCase):
 
         mock_cloud_service.launch_instance.assert_called_with(
             'vm1', # Should call launch_instance with Instance name from launch_vm
-            'flavor1', # Should call launch_instance with flavor from job.vm_flavor
+            'flavor1', # Should call launch_instance with flavor from job.vm_flavor_name
             CLOUD_CONFIG, # Should generate a cloud config with manage_etc_hosts, fs_setup, and write_files
             ['vol-id-123'] # Should call launch_instance with list of vol ids from create_volume
         )

--- a/lando/worker/config.py
+++ b/lando/worker/config.py
@@ -23,6 +23,7 @@ class WorkerConfig(object):
                 raise InvalidConfigException("Empty config file {}.".format(self.filename))
             self.work_queue_config = WorkQueue(data)
             self.cwl_base_command = data.get('cwl_base_command', None)
+            self.cwl_pre_process_command = data.get('cwl_pre_process_command', None)
             self.cwl_post_process_command = data.get('cwl_post_process_command', None)
             self.log_level = data.get('log_level', logging.WARNING)
 


### PR DESCRIPTION
Updates lando server to read VM settings like project, flavor, volume_mounts, volume_size, etc from Job rather than config.

- Requires https://github.com/Duke-GCB/bespin-api/pull/120 for changes to Job payload
- Removes the default VM flavor, since every job will specify the flavor
- Adds pre-processing command for CWL (e.g. make required directories)
- lando worker still reads its job-specific config (e.g. cwl command) from a config file, since the worker VM is job-specific and it does not communicate with bespin API

Fixes #92 