### PR TITLE
trap job action error handling exceptions

### DIFF
--- a/lando/server/lando.py
+++ b/lando/server/lando.py
@@ -330,8 +330,17 @@ class Lando(object):
                 getattr(actions, name)(payload)
             except:  # Trap all exceptions
                 tb = traceback.format_exc()
-                actions.generic_job_error(name, tb)
+                self._handle_action_error(actions, name, payload, tb)
         return action_method
+
+    def _handle_action_error(self, actions, name, payload, error_stacktrace_str):
+        try:
+            logging.info("Handling error that occurred during {} for job {}.".format(name, payload.job_id))
+            logging.info("Error contents: {}".format(error_stacktrace_str))
+            actions.generic_job_error(name, error_stacktrace_str)
+        except:
+            tb = traceback.format_exc()
+            logging.info("Additional error occurred while handling an error: {}".format(tb))
 
     def worker_started(self, worker_started_payload):
         """

--- a/lando/server/lando.py
+++ b/lando/server/lando.py
@@ -335,12 +335,12 @@ class Lando(object):
 
     def _handle_action_error(self, actions, name, payload, error_stacktrace_str):
         try:
-            logging.info("Handling error that occurred during {} for job {}.".format(name, payload.job_id))
-            logging.info("Error contents: {}".format(error_stacktrace_str))
+            logging.error("Handling error that occurred during {} for job {}.".format(name, payload.job_id))
+            logging.error("Error contents: {}".format(error_stacktrace_str))
             actions.generic_job_error(name, error_stacktrace_str)
         except:
             tb = traceback.format_exc()
-            logging.info("Additional error occurred while handling an error: {}".format(tb))
+            logging.error("Additional error occurred while handling an error: {}".format(tb))
 
     def worker_started(self, worker_started_payload):
         """

--- a/lando/server/tests/test_lando.py
+++ b/lando/server/tests/test_lando.py
@@ -532,7 +532,7 @@ Send progress notification. Job:1 State:E Step:V
         MockJobSettings.return_value = mock_settings
         lando = Lando(MagicMock())
         lando.start_job(MagicMock(job_id=job_id))
-        mock_logging.info.assert_has_calls([
+        mock_logging.error.assert_has_calls([
             call('Handling error that occurred during start_job for job 1.'),
             call('Error contents: StackTrace1'),
             call('Additional error occurred while handling an error: StackTrace2')


### PR DESCRIPTION
Adds try/except around handling exceptions raised by job actions.
Adds some additional logging so we record the error even if we are unable to access bespin api.
Fixes #105