### PR TITLE
Fix D4S2 url bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 LANDO_REQUIREMENTS = [
       "shade==1.24.0",
       "cwlref-runner==1.0",
-      "DukeDSClient==1.0.1",
+      "DukeDSClient==1.0.5",
       "humanfriendly==2.4",
       "Jinja2==2.9.5",
       "lando-messaging==0.7.3",

--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@ from setuptools import setup, find_packages
 
 
 LANDO_REQUIREMENTS = [
-      "shade==1.24.0",
+      "shade==1.29.0",
       "cwlref-runner==1.0",
-      "DukeDSClient==1.0.5",
+      "DukeDSClient==1.0.3",
       "humanfriendly==2.4",
       "Jinja2==2.9.5",
       "lando-messaging==0.7.3",


### PR DESCRIPTION
Fixing bug where lando was using the old D4S2 url.
Upgrading DukeDSClient will start using the new the D4S2 url: `datadelivery.genome.duke.edu`.

Upgrading to latest minor version of shade to fix installation issue with circleci.