### PR TITLE
switch to PyYAML 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ LANDO_REQUIREMENTS = [
       "lando-messaging==0.7.3",
       "Markdown==2.6.9",
       "python-dateutil==2.6.0",
-      "PyYAML==3.12",
+      "PyYAML==3.11",
       "requests==2.18.1",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ LANDO_REQUIREMENTS = [
       "lando-messaging==0.7.3",
       "Markdown==2.6.9",
       "python-dateutil==2.6.0",
-      "PyYAML==3.11",
+      "PyYAML<4",
       "requests==2.18.1",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ LANDO_REQUIREMENTS = [
       "lando-messaging==0.7.3",
       "Markdown==2.6.9",
       "python-dateutil==2.6.0",
-      "PyYAML<4",
+      "PyYAML>3,<4",
       "requests==2.18.1",
 ]
 


### PR DESCRIPTION
Fix to work around error when building lando worker image:
```
 Found existing installation: PyYAML 3.11\n\n:stderr: Cannot uninstall 'PyYAML'. 
It is a distutils installed project and thus we cannot accurately determine which files 
belong to it which would lead to only a partial uninstall
```