### PR TITLE
Switch to PyYAML 3.12 for compat with openstacksdk

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ LANDO_REQUIREMENTS = [
       "lando-messaging==0.7.4",
       "Markdown==2.6.9",
       "python-dateutil==2.6.0",
-      "PyYAML>3,<4",
+      "PyYAML==3.12",
       "requests==2.18.1",
 ]
 


### PR DESCRIPTION
Verified lando_worker_image builds in openstack with this PyYAML 3.12 requirement.

Fixes #131