### PR TITLE
Sanitize k8s names

### DIFF
--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -332,7 +332,7 @@ class JobManager(object):
 class Names(object):
     def __init__(self, job):
         job_id = job.id
-        suffix = '{}-{}'.format(job.id, job.username)
+        suffix = '{}-{}'.format(job.id, job.username).replace('@', '_')
         # Volumes
         self.job_data = 'job-data-{}'.format(suffix)
         self.output_data = 'output-data-{}'.format(suffix)

--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -2,6 +2,8 @@ from lando.k8s.cluster import BatchJobSpec, SecretVolume, PersistentClaimVolume,
     ConfigMapVolume, Container, FieldRefEnvVar
 import json
 import os
+import re
+
 
 DDSCLIENT_CONFIG_MOUNT_PATH = "/etc/ddsclient"
 TMP_VOLUME_SIZE_IN_G = 1
@@ -332,7 +334,8 @@ class JobManager(object):
 class Names(object):
     def __init__(self, job):
         job_id = job.id
-        suffix = '{}-{}'.format(job.id, job.username).replace('@', '-')
+        stripped_username = re.sub(r'@.*', '', job.username)
+        suffix = '{}-{}'.format(job.id, stripped_username)
         # Volumes
         self.job_data = 'job-data-{}'.format(suffix)
         self.output_data = 'output-data-{}'.format(suffix)

--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -332,7 +332,7 @@ class JobManager(object):
 class Names(object):
     def __init__(self, job):
         job_id = job.id
-        suffix = '{}-{}'.format(job.id, job.username).replace('@', '_')
+        suffix = '{}-{}'.format(job.id, job.username).replace('@', '-')
         # Volumes
         self.job_data = 'job-data-{}'.format(suffix)
         self.output_data = 'output-data-{}'.format(suffix)

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -432,6 +432,29 @@ class TestNames(TestCase):
         self.assertEqual(names.run_workflow_stdout_path, '/bespin/output-data/bespin-workflow-output.json')
         self.assertEqual(names.run_workflow_stderr_path, '/bespin/output-data/bespin-workflow-output.log')
 
+    def test_strips_username_after_at_sign(self):
+        mock_job = Mock(username='tom@tom.com', workflow=Mock(url='https://somewhere.com/someworkflow.cwl'))
+        mock_job.id = '123'
+        names = Names(mock_job)
+        self.assertEqual(names.job_data, 'job-data-123-tom')
+        self.assertEqual(names.output_data, 'output-data-123-tom')
+        self.assertEqual(names.tmpout, 'tmpout-123-tom')
+        self.assertEqual(names.tmp, 'tmp-123-tom')
+
+        self.assertEqual(names.stage_data, 'stage-data-123-tom')
+        self.assertEqual(names.run_workflow, 'run-workflow-123-tom')
+        self.assertEqual(names.organize_output, 'organize-output-123-tom')
+        self.assertEqual(names.save_output, 'save-output-123-tom')
+
+        self.assertEqual(names.user_data, 'user-data-123-tom')
+        self.assertEqual(names.data_store_secret, 'data-store-123-tom')
+        self.assertEqual(names.output_project_name, 'Bespin-job-123-results')
+        self.assertEqual(names.workflow_path, '/bespin/job-data/workflow/someworkflow.cwl')
+        self.assertEqual(names.job_order_path, '/bespin/job-data/job-order.json')
+        self.assertEqual(names.system_data, 'system-data-123-tom')
+        self.assertEqual(names.run_workflow_stdout_path, '/bespin/output-data/bespin-workflow-output.json')
+        self.assertEqual(names.run_workflow_stderr_path, '/bespin/output-data/bespin-workflow-output.log')
+
 
 class TestStageDataConfig(TestCase):
     def test_constructor(self):

--- a/lando/k8s/tests/test_lando.py
+++ b/lando/k8s/tests/test_lando.py
@@ -25,6 +25,7 @@ class TestK8sJobActions(TestCase):
         self.mock_job = Mock(state=JobStates.AUTHORIZED, step=JobSteps.NONE,
                              workflow=Mock(url='someurl.cwl'))
         self.mock_job.id = '49'
+        self.mock_job.username = 'joe@joe.com'
         self.mock_job_api = self.mock_settings.get_job_api.return_value
         self.mock_job_api.get_job.return_value = self.mock_job
 


### PR DESCRIPTION
Usernames from bespin api contained email addresses. This caused failures creating various k8s objects due the names containing `@` and `.`. To clean this up I am stripping everything after after and including `@` in the username provided by the bespin api job details.

Fixes #147 