### PR TITLE
Use bespin-api v2 for k8s support

### DIFF
--- a/lando/k8s/README.md
+++ b/lando/k8s/README.md
@@ -86,39 +86,10 @@ bespin_api:
   token: TODO
   url: TODO
 
-stage_data_settings:
-  image_name: lando-util:latest
-  command:
-    - python
-    - -m
-    - lando_util.download
-  requested_cpu: 1
-  requested_memory: 1G
-
 run_workflow_settings:
-  requested_cpu: 1
-  requested_memory: 2G
   system_data_volume:
      volume_claim_name: system-data
      mount_path: "/bespin/system/"
-
-organize_output_settings:
-  image_name: lando-util:latest
-  command:
-    - python
-    - -m
-    - lando_util.organize_project
-  requested_cpu: 1
-  requested_memory: 256M
-
-save_output_settings:
-  image_name: lando-util:latest
-  command:
-    - python
-    - -m
-    - lando_util.upload
-  requested_cpu: 1
-  requested_memory: 1G
 
 data_store_settings:
   secret_name: ddsclient-agent
@@ -133,7 +104,7 @@ log_level: INFO
 You will need to setup [bespin-api](https://github.com/Duke-GCB/gcb-ansible-roles/tree/master/bespin_web/tasks),
 [postgres](https://github.com/Duke-GCB/gcb-ansible-roles/tree/master/bespin_database/tasks) and [rabbitmq](https://github.com/Duke-GCB/gcb-ansible-roles/tree/master/bespin_rabbit/tasks) first to interact with k8s lando.
 
-`bespin-api` will need a vm settings with the appropriate image name and cwl base command
+`bespin-api` will need to have JobRuntimeK8s/JobRuntimeStepK8s with the appropriate image name and base commands setup
 ```
 - image name: `calrissian:latest`
 - cwl base command: `["python", "-m", "calrissian.main", "--max-ram", "16384", "--max-cores", "8"]`

--- a/lando/k8s/config.py
+++ b/lando/k8s/config.py
@@ -4,9 +4,6 @@ import os
 from lando.exceptions import get_or_raise_config_exception, InvalidConfigException
 from lando.server.config import WorkQueue, BespinApiSettings
 
-DEFAULT_REQUESTED_CPU = 1
-DEFAULT_REQUESTED_MEMORY = '1G'
-
 
 def create_server_config(filename):
     with open(filename, 'r') as infile:
@@ -32,21 +29,9 @@ class ServerConfig(object):
         self.data_store_settings = DataStoreSettings(
             get_or_raise_config_exception(data, 'data_store_settings')
         )
-        # settings for staging data in
-        self.stage_data_settings = ImageCommandSettings(
-            get_or_raise_config_exception(data, 'stage_data_settings')
-        )
         # settings for running a workflow
         self.run_workflow_settings = RunWorkflowSettings(
             get_or_raise_config_exception(data, 'run_workflow_settings')
-        )
-        # settings for organizing the results of running the workflow
-        self.organize_output_settings = ImageCommandSettings(
-            get_or_raise_config_exception(data, 'organize_output_settings')
-        )
-        # settings for uploading organized results
-        self.save_output_settings = ImageCommandSettings(
-            get_or_raise_config_exception(data, 'save_output_settings')
         )
         # settings for recording output project details
         self.record_output_project_settings = RecordOutputProjectSettings(
@@ -65,22 +50,11 @@ class ClusterApiSettings(object):
 
 class RecordOutputProjectSettings(object):
     def __init__(self, data):
-        self.image_name = get_or_raise_config_exception(data, 'image_name')
         self.service_account_name = get_or_raise_config_exception(data, 'service_account_name')
-
-
-class ImageCommandSettings(object):
-    def __init__(self, data):
-        self.image_name = get_or_raise_config_exception(data, 'image_name')
-        self.command = get_or_raise_config_exception(data, 'command')
-        self.requested_cpu = data.get('requested_cpu', DEFAULT_REQUESTED_CPU)
-        self.requested_memory = data.get('requested_memory', DEFAULT_REQUESTED_MEMORY)
 
 
 class RunWorkflowSettings(object):
     def __init__(self, data):
-        self.requested_cpu = data.get('requested_cpu', DEFAULT_REQUESTED_CPU)
-        self.requested_memory = data.get('requested_memory', DEFAULT_REQUESTED_MEMORY)
         self.system_data_volume = None
         if 'system_data_volume' in data:
             self.system_data_volume = SystemDataVolume(

--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -420,7 +420,7 @@ class StageDataConfig(object):
         self.data_store_secret_path = DDSCLIENT_CONFIG_MOUNT_PATH
         self.env_dict = {"DDSCLIENT_CONF": "{}/config".format(DDSCLIENT_CONFIG_MOUNT_PATH)}
 
-        job_stage_data_settings = job.k8s_command_set.stage_data
+        job_stage_data_settings = job.k8s_settings.stage_data
         self.image_name = job_stage_data_settings.image_name
         self.command = job_stage_data_settings.base_command
         self.requested_cpu = job_stage_data_settings.cpus
@@ -429,7 +429,7 @@ class StageDataConfig(object):
 
 class RunWorkflowConfig(object):
     def __init__(self, job, config):
-        job_run_workflow_settings = job.k8s_command_set.run_workflow
+        job_run_workflow_settings = job.k8s_settings.run_workflow
         self.image_name = job_run_workflow_settings.image_name
         self.command = job_run_workflow_settings.base_command
         self.requested_cpu = job_run_workflow_settings.cpus
@@ -444,7 +444,7 @@ class OrganizeOutputConfig(object):
         self.filename = "organizeoutput.json"
         self.path = '{}/{}'.format(Paths.CONFIG_DIR, self.filename)
 
-        job_organize_output_settings = job.k8s_command_set.organize_output
+        job_organize_output_settings = job.k8s_settings.organize_output
         self.image_name = job_organize_output_settings.image_name
         self.command = job_organize_output_settings.base_command
         self.requested_cpu = job_organize_output_settings.cpus
@@ -459,7 +459,7 @@ class SaveOutputConfig(object):
         self.data_store_secret_path = DDSCLIENT_CONFIG_MOUNT_PATH
         self.env_dict = {"DDSCLIENT_CONF": "{}/config".format(DDSCLIENT_CONFIG_MOUNT_PATH)}
 
-        job_save_output_settings = job.k8s_command_set.save_output
+        job_save_output_settings = job.k8s_settings.save_output
         self.image_name = job_save_output_settings.image_name
         self.command = job_save_output_settings.base_command
         self.requested_cpu = job_save_output_settings.cpus
@@ -468,7 +468,7 @@ class SaveOutputConfig(object):
 
 class RecordOutputProjectConfig(object):
     def __init__(self, job, config):
-        job_record_output_project_settings = job.k8s_command_set.record_output_project
+        job_record_output_project_settings = job.k8s_settings.record_output_project
 
         record_output_project_settings = config.record_output_project_settings
         self.image_name = job_record_output_project_settings.image_name

--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -324,6 +324,8 @@ class JobManager(object):
             args=[self.names.annotate_project_details_path],
             working_dir=Paths.OUTPUT_RESULTS_DIR,
             env_dict={"MY_POD_NAME": FieldRefEnvVar(field_path="metadata.name")},
+            requested_cpu=config.requested_cpu,
+            requested_memory=config.requested_memory,
             volumes=volumes)
         labels = self.make_job_labels(JobStepTypes.RECORD_OUTPUT_PROJECT)
         job_spec = BatchJobSpec(self.names.record_output_project,
@@ -412,28 +414,28 @@ class Paths(object):
 
 class StageDataConfig(object):
     def __init__(self, job, config):
-        # job parameter is not used but is here to allow future customization based on job
         self.filename = "stagedata.json"
         self.path = '{}/{}'.format(Paths.CONFIG_DIR, self.filename)
         self.data_store_secret_name = config.data_store_settings.secret_name
         self.data_store_secret_path = DDSCLIENT_CONFIG_MOUNT_PATH
         self.env_dict = {"DDSCLIENT_CONF": "{}/config".format(DDSCLIENT_CONFIG_MOUNT_PATH)}
 
-        stage_data_settings = config.stage_data_settings
-        self.image_name = stage_data_settings.image_name
-        self.command = stage_data_settings.command
-        self.requested_cpu = stage_data_settings.requested_cpu
-        self.requested_memory = stage_data_settings.requested_memory
+        job_stage_data_settings = job.k8s_command_set.stage_data
+        self.image_name = job_stage_data_settings.image_name
+        self.command = job_stage_data_settings.base_command
+        self.requested_cpu = job_stage_data_settings.cpus
+        self.requested_memory = job_stage_data_settings.memory
 
 
 class RunWorkflowConfig(object):
     def __init__(self, job, config):
-        self.image_name = job.vm_settings.image_name
-        self.command = job.vm_settings.cwl_commands.base_command
+        job_run_workflow_settings = job.k8s_command_set.run_workflow
+        self.image_name = job_run_workflow_settings.image_name
+        self.command = job_run_workflow_settings.base_command
+        self.requested_cpu = job_run_workflow_settings.cpus
+        self.requested_memory = job_run_workflow_settings.memory
 
         run_workflow_settings = config.run_workflow_settings
-        self.requested_cpu = run_workflow_settings.requested_cpu
-        self.requested_memory = run_workflow_settings.requested_memory
         self.system_data_volume = run_workflow_settings.system_data_volume
 
 
@@ -441,36 +443,37 @@ class OrganizeOutputConfig(object):
     def __init__(self, job, config):
         self.filename = "organizeoutput.json"
         self.path = '{}/{}'.format(Paths.CONFIG_DIR, self.filename)
-        # job parameter is not used but is here to allow future customization based on job
-        organize_output_settings = config.organize_output_settings
-        self.image_name = organize_output_settings.image_name
-        self.command = organize_output_settings.command
-        self.requested_cpu = organize_output_settings.requested_cpu
-        self.requested_memory = organize_output_settings.requested_memory
+
+        job_organize_output_settings = job.k8s_command_set.organize_output
+        self.image_name = job_organize_output_settings.image_name
+        self.command = job_organize_output_settings.base_command
+        self.requested_cpu = job_organize_output_settings.cpus
+        self.requested_memory = job_organize_output_settings.memory
 
 
 class SaveOutputConfig(object):
     def __init__(self, job, config):
-        # job parameter is not used but is here to allow future customization based on job
         self.filename = "saveoutput.json"
         self.path = '{}/{}'.format(Paths.CONFIG_DIR, self.filename)
         self.data_store_secret_name = config.data_store_settings.secret_name
         self.data_store_secret_path = DDSCLIENT_CONFIG_MOUNT_PATH
         self.env_dict = {"DDSCLIENT_CONF": "{}/config".format(DDSCLIENT_CONFIG_MOUNT_PATH)}
 
-        save_output_settings = config.save_output_settings
-        self.image_name = save_output_settings.image_name
-        self.command = save_output_settings.command
-        self.requested_cpu = save_output_settings.requested_cpu
-        self.requested_memory = save_output_settings.requested_memory
+        job_save_output_settings = job.k8s_command_set.save_output
+        self.image_name = job_save_output_settings.image_name
+        self.command = job_save_output_settings.base_command
+        self.requested_cpu = job_save_output_settings.cpus
+        self.requested_memory = job_save_output_settings.memory
 
 
 class RecordOutputProjectConfig(object):
     def __init__(self, job, config):
-        # job parameter is not used but is here to allow future customization based on job
+        job_record_output_project_settings = job.k8s_command_set.record_output_project
 
         record_output_project_settings = config.record_output_project_settings
-        self.image_name = record_output_project_settings.image_name
+        self.image_name = job_record_output_project_settings.image_name
+        self.requested_cpu = job_record_output_project_settings.cpus
+        self.requested_memory = job_record_output_project_settings.memory
         self.service_account_name = record_output_project_settings.service_account_name
         self.project_id_fieldname = 'project_id'
         self.readme_file_id_fieldname = 'readme_file_id'

--- a/lando/k8s/tests/test_config.py
+++ b/lando/k8s/tests/test_config.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
-from lando.k8s.config import create_server_config, InvalidConfigException, ServerConfig, DEFAULT_REQUESTED_MEMORY, \
-    DEFAULT_REQUESTED_CPU
+from lando.k8s.config import create_server_config, InvalidConfigException, ServerConfig
 from unittest.mock import patch
 import logging
 
@@ -25,21 +24,8 @@ MINIMAL_CONFIG = {
     'data_store_settings': {
         'secret_name': 'ddsclient-secret'
     },
-    'stage_data_settings': {
-        'image_name': 'lando-util:1',
-        'command': 'download.py',
-    },
     'run_workflow_settings': {},
-    'organize_output_settings': {
-        'image_name': 'lando-util:2',
-        'command': 'organize.py',
-    },
-    'save_output_settings': {
-        'image_name': 'lando-util:3',
-        'command': 'upload.py',
-    },
     'record_output_project_settings': {
-        'image_name': 'lachlanevenson/k8s-kubectl',
         'service_account_name': 'annotation-writer-sa',
     },
 }
@@ -67,34 +53,13 @@ FULL_CONFIG = {
     'data_store_settings': {
         'secret_name': 'ddsclient-secret'
     },
-    'stage_data_settings': {
-        'image_name': 'lando-util:1',
-        'command': 'download.py',
-        'requested_cpu': 2,
-        'requested_memory': '2G',
-    },
     'run_workflow_settings': {
-        'requested_cpu': 3,
-        'requested_memory': '3G',
         'system_data_volume': {
             'mount_path': '/system/data',
             'volume_claim_name': 'system-data',
         }
     },
-    'organize_output_settings': {
-        'image_name': 'lando-util:2',
-        'command': 'organize.py',
-        'requested_cpu': 4,
-        'requested_memory': '4G',
-    },
-    'save_output_settings': {
-        'image_name': 'lando-util:3',
-        'command': 'upload.py',
-        'requested_cpu': 5,
-        'requested_memory': '5G',
-    },
     'record_output_project_settings': {
-        'image_name': 'lachlanevenson/k8s-kubectl',
         'service_account_name': 'annotation-writer-sa',
     },
     'storage_class_name': 'gluster'
@@ -126,29 +91,8 @@ class TestServerConfig(TestCase):
         self.assertEqual(config.cluster_api_settings.verify_ssl, True)
 
         self.assertIsNotNone(config.bespin_api_settings)
-
         self.assertEqual(config.data_store_settings.secret_name, 'ddsclient-secret')
-
-        self.assertEqual(config.stage_data_settings.image_name, 'lando-util:1')
-        self.assertEqual(config.stage_data_settings.command, 'download.py')
-        self.assertEqual(config.stage_data_settings.requested_cpu, DEFAULT_REQUESTED_CPU)
-        self.assertEqual(config.stage_data_settings.requested_memory, DEFAULT_REQUESTED_MEMORY)
-
-        self.assertEqual(config.run_workflow_settings.requested_cpu, DEFAULT_REQUESTED_CPU)
-        self.assertEqual(config.run_workflow_settings.requested_memory, DEFAULT_REQUESTED_MEMORY)
         self.assertEqual(config.run_workflow_settings.system_data_volume, None)
-
-        self.assertEqual(config.organize_output_settings.image_name, 'lando-util:2')
-        self.assertEqual(config.organize_output_settings.command, 'organize.py')
-        self.assertEqual(config.organize_output_settings.requested_cpu, DEFAULT_REQUESTED_CPU)
-        self.assertEqual(config.organize_output_settings.requested_memory, DEFAULT_REQUESTED_MEMORY)
-
-        self.assertEqual(config.save_output_settings.image_name, 'lando-util:3')
-        self.assertEqual(config.save_output_settings.command, 'upload.py')
-        self.assertEqual(config.save_output_settings.requested_cpu, DEFAULT_REQUESTED_CPU)
-        self.assertEqual(config.save_output_settings.requested_memory, DEFAULT_REQUESTED_MEMORY)
-
-        self.assertEqual(config.record_output_project_settings.image_name, 'lachlanevenson/k8s-kubectl')
         self.assertEqual(config.record_output_project_settings.service_account_name, 'annotation-writer-sa')
 
         self.assertEqual(config.storage_class_name, None)
@@ -156,14 +100,6 @@ class TestServerConfig(TestCase):
     def test_optional_config(self):
         config = ServerConfig(FULL_CONFIG)
         self.assertEqual(config.log_level, logging.DEBUG)
-        self.assertEqual(config.stage_data_settings.requested_cpu, 2)
-        self.assertEqual(config.stage_data_settings.requested_memory, '2G')
-        self.assertEqual(config.run_workflow_settings.requested_cpu, 3)
-        self.assertEqual(config.run_workflow_settings.requested_memory, '3G')
         self.assertEqual(config.run_workflow_settings.system_data_volume.mount_path, '/system/data')
         self.assertEqual(config.run_workflow_settings.system_data_volume.volume_claim_name, 'system-data')
-        self.assertEqual(config.organize_output_settings.requested_cpu, 4)
-        self.assertEqual(config.organize_output_settings.requested_memory, '4G')
-        self.assertEqual(config.save_output_settings.requested_cpu, 5)
-        self.assertEqual(config.save_output_settings.requested_memory, '5G')
         self.assertEqual(config.cluster_api_settings.verify_ssl, False)

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -13,31 +13,31 @@ class TestJobManager(TestCase):
         self.mock_job = Mock(username='jpb', workflow=Mock(url='someurl', job_order=mock_job_order), volume_size=3)
         self.mock_job.id = '51'
         self.mock_job.vm_settings = None
-        self.mock_job.k8s_command_set.stage_data = Mock(
+        self.mock_job.k8s_settings.stage_data = Mock(
             image_name='image1',
             cpus=1,
             memory='1Gi',
             base_command=["python", "-m", "lando_util.download"],
         )
-        self.mock_job.k8s_command_set.run_workflow = Mock(
+        self.mock_job.k8s_settings.run_workflow = Mock(
             image_name='image2',
             cpus=2,
             memory='2Gi',
             base_command=["cwltool"],
         )
-        self.mock_job.k8s_command_set.organize_output = Mock(
+        self.mock_job.k8s_settings.organize_output = Mock(
             image_name='image3',
             cpus=3,
             memory='3Gi',
             base_command=["python", "-m", "lando_util.organize_project"],
         )
-        self.mock_job.k8s_command_set.save_output = Mock(
+        self.mock_job.k8s_settings.save_output = Mock(
             image_name='image4',
             cpus=4,
             memory='4Gi',
             base_command=["python", "-m", "lando_util.upload"],
         )
-        self.mock_job.k8s_command_set.record_output_project = Mock(
+        self.mock_job.k8s_settings.record_output_project = Mock(
             image_name='image5',
             cpus=5,
             memory='5Gi'
@@ -107,17 +107,17 @@ class TestJobManager(TestCase):
         self.assertEqual(batch_spec.labels['bespin-job-step'], 'stage_data')  # store the job step in a label
         job_container = batch_spec.container
         self.assertEqual(job_container.name, 'stage-data-51-jpb')  # container name
-        self.assertEqual(job_container.image_name, self.mock_job.k8s_command_set.stage_data.image_name,
+        self.assertEqual(job_container.image_name, self.mock_job.k8s_settings.stage_data.image_name,
                          'stage data image name is based on a job setting')
-        self.assertEqual(job_container.command, self.mock_job.k8s_command_set.stage_data.base_command,
+        self.assertEqual(job_container.command, self.mock_job.k8s_settings.stage_data.base_command,
                          'stage data command is based on a job setting')
         self.assertEqual(job_container.args, ['/bespin/config/stagedata.json'],
                          'stage data command should receive config file as an argument')
         self.assertEqual(job_container.env_dict, {'DDSCLIENT_CONF': '/etc/ddsclient/config'},
                          'DukeDS environment variable should point to the config mapped config file')
-        self.assertEqual(job_container.requested_cpu, self.mock_job.k8s_command_set.stage_data.cpus,
+        self.assertEqual(job_container.requested_cpu, self.mock_job.k8s_settings.stage_data.cpus,
                          'stage data requested cpu is based on a config setting')
-        self.assertEqual(job_container.requested_memory, self.mock_job.k8s_command_set.stage_data.memory,
+        self.assertEqual(job_container.requested_memory, self.mock_job.k8s_settings.stage_data.memory,
                          'stage data requested memory is based on a config setting')
         self.assertEqual(len(job_container.volumes), 3)
 
@@ -182,7 +182,7 @@ class TestJobManager(TestCase):
         self.assertEqual(batch_spec.labels['bespin-job-step'], 'run_workflow')  # store the job step in a label
         job_container = batch_spec.container
         self.assertEqual(job_container.name, 'run-workflow-51-jpb')  # container name
-        self.assertEqual(job_container.image_name, self.mock_job.k8s_command_set.run_workflow.image_name,
+        self.assertEqual(job_container.image_name, self.mock_job.k8s_settings.run_workflow.image_name,
                          'run workflow image name is based on job settings')
 
         self.assertEqual(job_container.command, ['bash', '-c', 'cwltool --tmp-outdir-prefix /bespin/tmpout/ '
@@ -195,9 +195,9 @@ class TestJobManager(TestCase):
                          'run workflow command combines job settings and staged files')
         self.assertEqual(job_container.env_dict['CALRISSIAN_POD_NAME'].field_path, 'metadata.name',
                          'We should store the pod name in a CALRISSIAN_POD_NAME environment variable')
-        self.assertEqual(job_container.requested_cpu, self.mock_job.k8s_command_set.run_workflow.cpus,
+        self.assertEqual(job_container.requested_cpu, self.mock_job.k8s_settings.run_workflow.cpus,
                          'run workflow requested cpu is based on a job setting')
-        self.assertEqual(job_container.requested_memory, self.mock_job.k8s_command_set.run_workflow.memory,
+        self.assertEqual(job_container.requested_memory, self.mock_job.k8s_settings.run_workflow.memory,
                          'run workflow requested memory is based on a job setting')
 
         self.assertEqual(len(job_container.volumes), 5)
@@ -265,13 +265,13 @@ class TestJobManager(TestCase):
         self.assertEqual(batch_spec.labels['bespin-job-step'], 'organize_output')  # store the job step in a label
         job_container = batch_spec.container
         self.assertEqual(job_container.name, 'organize-output-51-jpb')  # container name
-        self.assertEqual(job_container.image_name, self.mock_job.k8s_command_set.organize_output.image_name,
+        self.assertEqual(job_container.image_name, self.mock_job.k8s_settings.organize_output.image_name,
                          'organize output image name is based on job settings')
-        self.assertEqual(job_container.command, self.mock_job.k8s_command_set.organize_output.base_command,
+        self.assertEqual(job_container.command, self.mock_job.k8s_settings.organize_output.base_command,
                          'organize output command is based on job settings')
-        self.assertEqual(job_container.requested_cpu, self.mock_job.k8s_command_set.organize_output.cpus,
+        self.assertEqual(job_container.requested_cpu, self.mock_job.k8s_settings.organize_output.cpus,
                          'organize output requested cpu is based on a job setting')
-        self.assertEqual(job_container.requested_memory, self.mock_job.k8s_command_set.organize_output.memory,
+        self.assertEqual(job_container.requested_memory, self.mock_job.k8s_settings.organize_output.memory,
                          'organize output requested memory is based on a job setting')
 
         mock_cluster_api.create_config_map.assert_called_with(
@@ -351,18 +351,18 @@ class TestJobManager(TestCase):
         self.assertEqual(batch_spec.labels['bespin-job-step'], 'save_output')  # store the job step in a label
         job_container = batch_spec.container
         self.assertEqual(job_container.name, 'save-output-51-jpb')  # container name
-        self.assertEqual(job_container.image_name, self.mock_job.k8s_command_set.save_output.image_name,
+        self.assertEqual(job_container.image_name, self.mock_job.k8s_settings.save_output.image_name,
                          'save output image name is based on a job setting')
-        self.assertEqual(job_container.command, self.mock_job.k8s_command_set.save_output.base_command,
+        self.assertEqual(job_container.command, self.mock_job.k8s_settings.save_output.base_command,
                          'save output command is based on a job setting')
         self.assertEqual(job_container.args,
                          ['/bespin/config/saveoutput.json', '/bespin/output-data/annotate_project_details.sh'],
                          'save output command should receive config file and output filenames as arguments')
         self.assertEqual(job_container.env_dict, {'DDSCLIENT_CONF': '/etc/ddsclient/config'},
                          'DukeDS environment variable should point to the config mapped config file')
-        self.assertEqual(job_container.requested_cpu, self.mock_job.k8s_command_set.save_output.cpus,
+        self.assertEqual(job_container.requested_cpu, self.mock_job.k8s_settings.save_output.cpus,
                          'stage data requested cpu is based on a job setting')
-        self.assertEqual(job_container.requested_memory, self.mock_job.k8s_command_set.save_output.memory,
+        self.assertEqual(job_container.requested_memory, self.mock_job.k8s_settings.save_output.memory,
                          'stage data requested memory is based on a job setting')
         self.assertEqual(len(job_container.volumes), 4)
 
@@ -421,7 +421,7 @@ class TestJobManager(TestCase):
         self.assertEqual(batch_spec.labels['bespin-job-step'], 'record_output_project')  # store the job step in a label
         job_container = batch_spec.container
         self.assertEqual(job_container.name, 'record-output-project-51-jpb')  # container name
-        self.assertEqual(job_container.image_name, self.mock_job.k8s_command_set.record_output_project.image_name,
+        self.assertEqual(job_container.image_name, self.mock_job.k8s_settings.record_output_project.image_name,
                          'record output project image name is based on a config setting')
         self.assertEqual(job_container.command, ['sh'],
                          'record output project base command is sh')
@@ -571,10 +571,10 @@ class TestNames(TestCase):
 class TestStageDataConfig(TestCase):
     def test_constructor(self):
         mock_job = Mock()
-        mock_job.k8s_command_set.stage_data.image_name = 'someimage'
-        mock_job.k8s_command_set.stage_data.cpus = 6
-        mock_job.k8s_command_set.stage_data.memory = '6Gi'
-        mock_job.k8s_command_set.stage_data.base_command = ['upload']
+        mock_job.k8s_settings.stage_data.image_name = 'someimage'
+        mock_job.k8s_settings.stage_data.cpus = 6
+        mock_job.k8s_settings.stage_data.memory = '6Gi'
+        mock_job.k8s_settings.stage_data.base_command = ['upload']
         mock_config = Mock()
         config = StageDataConfig(job=mock_job, config=mock_config)
         self.assertEqual(config.path, '/bespin/config/stagedata.json')
@@ -590,10 +590,10 @@ class TestStageDataConfig(TestCase):
 class TestRunWorkflowConfig(TestCase):
     def test_constructor(self):
         mock_job = Mock()
-        mock_job.k8s_command_set.run_workflow.image_name = 'someimage'
-        mock_job.k8s_command_set.run_workflow.cpus = 16
-        mock_job.k8s_command_set.run_workflow.memory = '4Gi'
-        mock_job.k8s_command_set.run_workflow.base_command = ['cwltool']
+        mock_job.k8s_settings.run_workflow.image_name = 'someimage'
+        mock_job.k8s_settings.run_workflow.cpus = 16
+        mock_job.k8s_settings.run_workflow.memory = '4Gi'
+        mock_job.k8s_settings.run_workflow.base_command = ['cwltool']
         mock_config = Mock()
         config = RunWorkflowConfig(job=mock_job, config=mock_config)
         self.assertEqual(config.image_name, 'someimage')
@@ -606,10 +606,10 @@ class TestRunWorkflowConfig(TestCase):
 class TestOrganizeOutputConfig(TestCase):
     def test_constructor(self):
         mock_job = Mock()
-        mock_job.k8s_command_set.organize_output.image_name = 'someimage'
-        mock_job.k8s_command_set.organize_output.base_command = ['organizeit']
-        mock_job.k8s_command_set.organize_output.cpus = 8
-        mock_job.k8s_command_set.organize_output.memory = '1Gi'
+        mock_job.k8s_settings.organize_output.image_name = 'someimage'
+        mock_job.k8s_settings.organize_output.base_command = ['organizeit']
+        mock_job.k8s_settings.organize_output.cpus = 8
+        mock_job.k8s_settings.organize_output.memory = '1Gi'
         mock_config = Mock()
         config = OrganizeOutputConfig(job=mock_job, config=mock_config)
         self.assertEqual(config.filename, "organizeoutput.json")
@@ -623,10 +623,10 @@ class TestOrganizeOutputConfig(TestCase):
 class TestSaveOutputConfig(TestCase):
     def test_constructor(self):
         mock_job = Mock()
-        mock_job.k8s_command_set.save_output.image_name = 'someimage'
-        mock_job.k8s_command_set.save_output.base_command = ['upload']
-        mock_job.k8s_command_set.save_output.cpus = 4
-        mock_job.k8s_command_set.save_output.memory = '2Gi'
+        mock_job.k8s_settings.save_output.image_name = 'someimage'
+        mock_job.k8s_settings.save_output.base_command = ['upload']
+        mock_job.k8s_settings.save_output.cpus = 4
+        mock_job.k8s_settings.save_output.memory = '2Gi'
         mock_config = Mock()
         config = SaveOutputConfig(job=mock_job, config=mock_config)
         self.assertEqual(config.path, '/bespin/config/saveoutput.json')
@@ -642,9 +642,9 @@ class TestSaveOutputConfig(TestCase):
 class TestRecordOutputProjectConfig(TestCase):
     def test_constructor(self):
         mock_job = Mock()
-        mock_job.k8s_command_set.record_output_project.image_name = 'someimage'
-        mock_job.k8s_command_set.record_output_project.cpus = 1
-        mock_job.k8s_command_set.record_output_project.memory = '1MB'
+        mock_job.k8s_settings.record_output_project.image_name = 'someimage'
+        mock_job.k8s_settings.record_output_project.cpus = 1
+        mock_job.k8s_settings.record_output_project.memory = '1MB'
         mock_config = Mock()
         config = RecordOutputProjectConfig(job=mock_job, config=mock_config)
         self.assertEqual(config.image_name, 'someimage')

--- a/lando/server/cloudservice.py
+++ b/lando/server/cloudservice.py
@@ -17,12 +17,12 @@ class CloudClient(object):
         """
         self.cloud = shade.openstack_cloud(**credentials)
 
-    def launch_instance(self, vm_settings, server_name, vm_flavor_name, script_contents, volumes):
+    def launch_instance(self, vm_settings, server_name, job_flavor_name, script_contents, volumes):
         """
         Start VM with the specified settings, name, and script to run on startup.
         :param vm_settings: config.VMSettings: settings for VM we want to create
         :param server_name: str: unique name for this VM
-        :param vm_flavor_name: str: name of flavor(RAM/CPUs) to use for the VM
+        :param job_flavor_name: str: name of flavor(RAM/CPUs) to use for the VM
         :param script_contents: str: contents of a cloud-init script (bash or #cloud-config)
         :param volumes: [str]: list of volume ids to attach to the VM
         :return: openstack instance created
@@ -30,7 +30,7 @@ class CloudClient(object):
         instance = self.cloud.create_server(
             name=server_name,
             image=vm_settings.image_name,
-            flavor=vm_flavor_name,    # The flavor 'Root Disk' value has no effect due to using a volume for storage
+            flavor=job_flavor_name,    # The flavor 'Root Disk' value has no effect due to using a volume for storage
             key_name=vm_settings.ssh_key_name,
             network=vm_settings.network_name,
             auto_ip=vm_settings.allocate_floating_ips,

--- a/lando/server/jobapi.py
+++ b/lando/server/jobapi.py
@@ -301,7 +301,7 @@ class Job(object):
         self.name = data['name']
         self.state = data['state']
         self.step = data['step']
-        self.vm_flavor_name = data['job_flavor']['name']
+        self.job_flavor_name = data['job_flavor']['name']
         self.vm_instance_name = data['vm_instance_name']
         self.vm_volume_name = data['vm_volume_name']
         self.stage_group = data['stage_group']

--- a/lando/server/lando.py
+++ b/lando/server/lando.py
@@ -198,7 +198,7 @@ class JobActions(BaseJobActions):
         cloud_config_script.add_manage_etc_hosts()
         cloud_service = self._get_cloud_service(job)
         volume, volume_id = cloud_service.create_volume(job.volume_size, vm_volume_name)
-        instance, ip_address = cloud_service.launch_instance(vm_instance_name, job.vm_flavor_name, cloud_config_script.content,
+        instance, ip_address = cloud_service.launch_instance(vm_instance_name, job.job_flavor_name, cloud_config_script.content,
                                                              [volume_id])
         self._show_status("Launched vm with ip {}".format(ip_address))
         self.job_api.set_vm_instance_name(vm_instance_name)

--- a/lando/server/tests/test_cloudservice.py
+++ b/lando/server/tests/test_cloudservice.py
@@ -7,7 +7,7 @@ from unittest import mock
 class TestCloudService(TestCase):
     @mock.patch('lando.server.cloudservice.CloudClient')
     def test_makes_cloud_client(self, mock_cloud_client):
-        mock_credentials = mock.Mock() # a function that returns credentials
+        mock_credentials = mock.Mock()  # a function that returns credentials
         config = mock.MagicMock(cloud_settings=mock.MagicMock(credentials=mock_credentials))
         vm_settings = mock.MagicMock(vm_project_name='test-project')
         service = CloudService(config, vm_settings)

--- a/lando/server/tests/test_jobapi.py
+++ b/lando/server/tests/test_jobapi.py
@@ -75,7 +75,7 @@ class TestJobApi(TestCase):
         self.assertEqual(23, job.user_id)
         self.assertEqual('joe@joe.com', job.username)
         self.assertEqual('N', job.state)
-        self.assertEqual('m1.tiny', job.vm_flavor_name)
+        self.assertEqual('m1.tiny', job.job_flavor_name)
         self.assertEqual('', job.vm_instance_name)
         self.assertEqual('', job.vm_volume_name)
         self.assertEqual(True, job.cleanup_vm)

--- a/lando/server/tests/test_jobapi.py
+++ b/lando/server/tests/test_jobapi.py
@@ -19,10 +19,9 @@ class TestJobApi(TestCase):
             'step': '',
             'name': 'myjob',
             'created': '2017-03-21T13:29:09.123603Z',
-            'vm_flavor': {
+            'job_flavor': {
                 'name': 'm1.tiny',
             },
-            'vm_settings':'mock_vm_settings',
             'vm_instance_name': '',
             'vm_volume_name': '',
             'vm_volume_mounts': '{}',
@@ -33,6 +32,9 @@ class TestJobApi(TestCase):
                 'url': 'file:///mnt/fastqc.cwl',
                 'object_name': '#main',
                 "methods_document": 7,
+            },
+            'job_settings': {
+                'vm_command': 'mock_vm_settings'
             },
             'output_project': {
                 'id': 5,
@@ -173,7 +175,7 @@ class TestJobApi(TestCase):
             },
             'state': 'N',
             'step': '',
-            'vm_flavor': {
+            'job_flavor': {
                 'name': 'm1.tiny',
             },
             'vm_instance_name': '',
@@ -188,6 +190,10 @@ class TestJobApi(TestCase):
                 'name': 'SomeWorkflow',
                 'version': 1,
                 "methods_document": 7,
+            },
+            'job_settings': {
+                'vm_command': {},
+                'k8s_step_commands': {},
             },
             'output_project': {
                 'id': 5,
@@ -235,7 +241,7 @@ class TestJobApi(TestCase):
                 'step': '',
                 'name': 'SomeJob',
                 'created': '2017-03-21T13:29:09.123603Z',
-                'vm_flavor': {
+                'job_flavor': {
                     'name': 'm1.tiny',
                 },
                 'vm_instance_name': '',
@@ -249,6 +255,7 @@ class TestJobApi(TestCase):
                     'version': 1,
                     "methods_document": 7,
                 },
+                'job_settings': {},
                 'output_project': {
                     'id': 5,
                     'dds_user_credentials': 123
@@ -381,7 +388,7 @@ class TestJob(TestCase):
             'step': '',
             'name': 'myjob',
             'created': '2017-03-21T13:29:09.123603Z',
-            'vm_flavor': {
+            'job_flavor': {
                 'name': 'm1.tiny',
             },
             'vm_instance_name': '',
@@ -394,6 +401,12 @@ class TestJob(TestCase):
                 'url': 'file:///mnt/fastqc.cwl',
                 'object_name': '#main',
                 "methods_document": 7,
+            },
+            'job_settings': {
+                'vm_command': {
+
+                },
+                'k8s_step_commands': None
             },
             'output_project': {
                 'id': 5,

--- a/lando/server/tests/test_jobapi.py
+++ b/lando/server/tests/test_jobapi.py
@@ -1,10 +1,12 @@
 
 from unittest import TestCase
+import copy
 from lando.server.jobapi import JobApi, BespinApi, Job, CWLCommand, VMSettings
 from unittest.mock import MagicMock, patch, call
 
 
 @patch('lando.server.jobapi.VMSettings')
+@patch('lando.server.jobapi.K8sSettings')
 @patch('lando.server.jobapi.requests')
 class TestJobApi(TestCase):
 
@@ -34,7 +36,8 @@ class TestJobApi(TestCase):
                 "methods_document": 7,
             },
             'job_settings': {
-                'vm_command': 'mock_vm_settings'
+                'job_runtime_openstack': 'mock_job_settings',
+                'job_runtime_k8s': None,
             },
             'output_project': {
                 'id': 5,
@@ -55,7 +58,7 @@ class TestJobApi(TestCase):
         job_api.api.headers = empty_headers
         return job_api
 
-    def test_get_job_api(self, mock_requests, mock_vm_settings):
+    def test_get_job_api(self, mock_requests, mock_k8s_settings, mock_vm_settings):
         """
         Test requesting job status, etc
         """
@@ -78,12 +81,12 @@ class TestJobApi(TestCase):
         self.assertEqual(True, job.cleanup_vm)
         args, kwargs = mock_vm_settings.call_args
         # Should call VMSettings() with contents of data['vm_settings']
-        self.assertEqual(args[0], 'mock_vm_settings')
+        self.assertEqual(args[0], 'mock_job_settings')
         self.assertEqual('{ "value": 1 }', job.workflow.job_order)
         self.assertEqual('file:///mnt/fastqc.cwl', job.workflow.url)
         self.assertEqual('#main', job.workflow.object_name)
 
-    def test_set_job_state(self, mock_requests, mock_vm_settings):
+    def test_set_job_state(self, mock_requests, mock_k8s_settings, mock_vm_settings):
         job_api = self.setup_job_api(2)
         mock_response = MagicMock()
         mock_response.json.return_value = {}
@@ -93,7 +96,7 @@ class TestJobApi(TestCase):
         self.assertEqual(args[0], 'APIURL/admin/jobs/2/')
         self.assertEqual(kwargs.get('json'), {'state': 'E'})
 
-    def test_set_job_step(self, mock_requests, mock_vm_settings):
+    def test_set_job_step(self, mock_requests, mock_k8s_settings, mock_vm_settings):
         job_api = self.setup_job_api(2)
         mock_response = MagicMock()
         mock_response.json.return_value = {}
@@ -103,7 +106,7 @@ class TestJobApi(TestCase):
         self.assertEqual(args[0], 'APIURL/admin/jobs/2/')
         self.assertEqual(kwargs.get('json'), {'step': 'N'})
 
-    def test_set_vm_instance_name(self, mock_requests, mock_vm_settings):
+    def test_set_vm_instance_name(self, mock_requests, mock_k8s_settings, mock_vm_settings):
         job_api = self.setup_job_api(3)
         mock_response = MagicMock()
         mock_response.json.return_value = mock_response
@@ -113,7 +116,7 @@ class TestJobApi(TestCase):
         self.assertEqual(args[0], 'APIURL/admin/jobs/3/')
         self.assertEqual(kwargs.get('json'), {'vm_instance_name': 'worker_123'})
 
-    def test_set_vm_volume_name(self, mock_requests, mock_vm_settings):
+    def test_set_vm_volume_name(self, mock_requests, mock_k8s_settings, mock_vm_settings):
         job_api = self.setup_job_api(3)
         mock_response = MagicMock()
         mock_response.json.return_value = mock_response
@@ -123,7 +126,7 @@ class TestJobApi(TestCase):
         self.assertEqual(args[0], 'APIURL/admin/jobs/3/')
         self.assertEqual(kwargs.get('json'), {'vm_volume_name': 'volume_765'})
 
-    def test_get_input_files(self, mock_requests, mock_vm_settings):
+    def test_get_input_files(self, mock_requests, mock_k8s_settings, mock_vm_settings):
         self.job_response_payload['stage_group'] = '4'
         stage_group_response_payload = {
                 'dds_files': [
@@ -163,7 +166,7 @@ class TestJobApi(TestCase):
         self.assertEqual('https://stuff.com/file123.model', url_file.url)
         self.assertEqual('file123.model', url_file.destination_path)
 
-    def test_get_credentials(self, mock_requests, mock_vm_settings):
+    def test_get_credentials(self, mock_requests, mock_k8s_settings, mock_vm_settings):
         """
         The only stored credentials are the bespin system credentials.
         """
@@ -192,8 +195,8 @@ class TestJobApi(TestCase):
                 "methods_document": 7,
             },
             'job_settings': {
-                'vm_command': {},
-                'k8s_step_commands': {},
+                'job_runtime_openstack': {},
+                'job_runtime_k8s': {},
             },
             'output_project': {
                 'id': 5,
@@ -229,7 +232,7 @@ class TestJobApi(TestCase):
         self.assertEqual('2191230', user_cred.endpoint_agent_key)
         self.assertEqual('localhost/api/v1/', user_cred.endpoint_api_root)
 
-    def test_get_jobs_for_vm_instance_name(self, mock_requests, mock_vm_settings):
+    def test_get_jobs_for_vm_instance_name(self, mock_requests, mock_k8s_settings, mock_vm_settings):
         jobs_response = [
             {
                 'id': 1,
@@ -255,7 +258,10 @@ class TestJobApi(TestCase):
                     'version': 1,
                     "methods_document": 7,
                 },
-                'job_settings': {},
+                'job_settings': {
+                    'job_runtime_openstack': None,
+                    'job_runtime_k8s': None
+                },
                 'output_project': {
                     'id': 5,
                     'dds_user_credentials': 123
@@ -274,7 +280,7 @@ class TestJobApi(TestCase):
         jobs = JobApi.get_jobs_for_vm_instance_name(mock_config, 'joe')
         self.assertEqual(1, len(jobs))
 
-    def test_post_error(self, mock_requests, mock_vm_settings):
+    def test_post_error(self, mock_requests, mock_k8s_settings, mock_vm_settings):
         mock_response = MagicMock()
         mock_response.json.return_value = {}
         mock_requests.get.return_value = mock_response
@@ -286,14 +292,14 @@ class TestJobApi(TestCase):
         self.assertEqual(kwargs['json']['job_step'], 'V')
         self.assertEqual(kwargs['json']['content'], 'Out of memory')
 
-    def test_job_constructor_volume_size(self, mock_requests, mock_vm_settings):
+    def test_job_constructor_volume_size(self, mock_requests, mock_k8s_settings, mock_vm_settings):
         payload = dict(self.job_response_payload)
         payload['volume_size'] = 1000
         job = Job(payload)
         self.assertEqual(job.volume_size, 1000,
                          "A job payload with volume_size should result in that volume size.")
 
-    def test_get_store_output_job_data(self, mock_requests, mock_vm_settings):
+    def test_get_store_output_job_data(self, mock_requests, mock_k8s_settings, mock_vm_settings):
         """
         Test requesting job status, etc
         """
@@ -329,7 +335,7 @@ class TestJobApi(TestCase):
 
         self.assertEqual(['123'], store_output_data.share_dds_ids)
 
-    def test_get_run_job_data(self, mock_requests, mock_vm_settings):
+    def test_get_run_job_data(self, mock_requests, mock_k8s_settings, mock_vm_settings):
         mock_response1 = MagicMock()
         mock_response1.json.return_value = self.job_response_payload
         mock_response2 = MagicMock()
@@ -346,7 +352,7 @@ class TestJobApi(TestCase):
         #args, kwargs = mock_requests.get.call_args
         #self.assertEqual(args[0], 'APIURL/admin/workflow-methods-documents/123')
 
-    def test_get_workflow_methods_document(self, mock_requests, mock_vm_settings):
+    def test_get_workflow_methods_document(self, mock_requests, mock_k8s_settings, mock_vm_settings):
         mock_response = MagicMock()
         mock_response.json.return_value = {'content': '#Markdown'}
         mock_requests.get.return_value = mock_response
@@ -356,7 +362,7 @@ class TestJobApi(TestCase):
         args, kwargs = mock_requests.get.call_args
         self.assertEqual(args[0], 'APIURL/admin/workflow-methods-documents/123')
 
-    def test_save_project_details(self, mock_requests, mock_vm_settings):
+    def test_save_project_details(self, mock_requests, mock_k8s_settings, mock_vm_settings):
         mock_response = MagicMock()
         mock_response.json.return_value = self.job_response_payload
         mock_requests.get.return_value = mock_response
@@ -378,7 +384,7 @@ class TestJobApi(TestCase):
 
 class TestJob(TestCase):
     def setUp(self):
-        self.job_data = {
+        job_data = {
             'id': 1,
             'user': {
                 'id': 23,
@@ -403,10 +409,8 @@ class TestJob(TestCase):
                 "methods_document": 7,
             },
             'job_settings': {
-                'vm_command': {
-
-                },
-                'k8s_step_commands': None
+                'job_runtime_openstack': None,
+                'job_runtime_k8s': None
             },
             'output_project': {
                 'id': 5,
@@ -416,25 +420,116 @@ class TestJob(TestCase):
             'share_group': 42,
             'volume_size': 100,
         }
+        self.vm_job_data = copy.deepcopy(job_data)
+        self.vm_job_data['job_settings']['name'] = 'vm'
+        self.vm_job_data['job_settings']['job_runtime_openstack'] = {
+            "image_name": "myimage",
+            "cwl_base_command": [
+                "cwltool"
+            ],
+            "cwl_post_process_command": [
+                "cleanup.sh"
+            ],
+            "cwl_pre_process_command": [
+                "prep.sh"
+            ]
+        }
+        self.k8s_job_data = copy.deepcopy(job_data)
+        self.k8s_job_data['job_settings']['name'] = 'k8s'
+        self.k8s_job_data['job_settings']['job_runtime_k8s'] = {
+            "id": 1,
+            "steps": [
+                {
+                    "id": 1,
+                    "flavor": {
+                        "id": 1,
+                        "name": "small",
+                        "cpus": 1,
+                        "memory": "1Gi"
+                    },
+                    "step_type": "stage_data",
+                    "image_name": "lando-util:latest",
+                    "base_command": [
+                        "download"
+                    ]
+                },
+                {
+                    "id": 2,
+                    "flavor": {
+                        "id": 2,
+                        "name": "large",
+                        "cpus": 32,
+                        "memory": "64Gi"
+                    },
+                    "step_type": "run_workflow",
+                    "image_name": "dukegcb/calrissian:0.2.1",
+                    "base_command": [
+                        "calrissian"
+                    ]
+                },
+                {
+                    "id": 3,
+                    "flavor": {
+                        "id": 1,
+                        "name": "small",
+                        "cpus": 1,
+                        "memory": "1Gi"
+                    },
+                    "step_type": "organize_output",
+                    "image_name": "lando-util:latest",
+                    "base_command": [
+                        "sort"
+                    ]
+                },
+                {
+                    "id": 4,
+                    "flavor": {
+                        "id": 1,
+                        "name": "small",
+                        "cpus": 1,
+                        "memory": "1Gi"
+                    },
+                    "step_type": "save_output",
+                    "image_name": "lando-util:latest",
+                    "base_command": [
+                        "upload"
+                    ]
+                },
+                {
+                    "id": 5,
+                    "flavor": {
+                        "id": 1,
+                        "name": "small",
+                        "cpus": 1,
+                        "memory": "1Gi"
+                    },
+                    "step_type": "record_output_project",
+                    "image_name": "lando-util:latest",
+                    "base_command": [
+                        "saveoutput"
+                    ]
+                }
+            ]
+        }
 
     @patch('lando.server.jobapi.VMSettings')
     def test_cleanup_vm_default(self, mock_vm_settings):
         mock_data = MagicMock()
-        job = Job(self.job_data)
+        job = Job(self.vm_job_data)
         self.assertEqual(job.cleanup_vm, True)
 
     @patch('lando.server.jobapi.VMSettings')
     def test_cleanup_vm_true(self, mock_vm_settings):
-        self.job_data['cleanup_vm'] = True
+        self.vm_job_data['cleanup_vm'] = True
         mock_data = MagicMock()
-        job = Job(self.job_data)
+        job = Job(self.vm_job_data)
         self.assertEqual(job.cleanup_vm, True)
 
     @patch('lando.server.jobapi.VMSettings')
     def test_cleanup_vm_false(self, mock_vm_settings):
-        self.job_data['cleanup_vm'] = False
+        self.vm_job_data['cleanup_vm'] = False
         mock_data = MagicMock()
-        job = Job(self.job_data)
+        job = Job(self.vm_job_data)
         self.assertEqual(job.cleanup_vm, False)
 
 

--- a/lando/server/tests/test_lando.py
+++ b/lando/server/tests/test_lando.py
@@ -118,7 +118,7 @@ class Report(object):
         job.user_id = '1'
         job.state = self.job_state
         job.step = self.job_step
-        job.vm_flavor_name = ''
+        job.job_flavor_name = ''
         job.vm_instance_name = self.vm_instance_name
         job.vm_volume_name = self.vm_volume_name
         job.vm_project_name = 'bespin_user1'
@@ -612,7 +612,7 @@ class TestJobActions(TestCase):
 
     def test_launch_vm(self):
         mock_vm_settings = Mock(cwl_commands=None)
-        mock_job = Mock(id='1', state='', step='', cleanup_vm=False, vm_flavor_name='flavor1',
+        mock_job = Mock(id='1', state='', step='', cleanup_vm=False, job_flavor_name='flavor1',
                         volume_mounts={'/dev/vdb1':'/work'}, vm_settings=mock_vm_settings)
         mock_job_api = MagicMock()
         mock_job_api.get_job.return_value = mock_job
@@ -635,7 +635,7 @@ class TestJobActions(TestCase):
 
         mock_cloud_service.launch_instance.assert_called_with(
             'vm1', # Should call launch_instance with Instance name from launch_vm
-            'flavor1', # Should call launch_instance with flavor from job.vm_flavor_name
+            'flavor1', # Should call launch_instance with flavor from job.job_flavor_name
             CLOUD_CONFIG, # Should generate a cloud config with manage_etc_hosts, fs_setup, and write_files
             ['vol-id-123'] # Should call launch_instance with list of vol ids from create_volume
         )


### PR DESCRIPTION
Removes k8s step config settings for image name, base command, cpus, memory.
Adds code to read k8s step config(image name, base command, cpus, memory) from bespin-api v2 job payload.
Changes to update parsing job response due to bespin-api v2 changes.