### PR TITLE
pass job cpu/memory to calrissian

### DIFF
--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -169,7 +169,10 @@ class JobManager(object):
                 read_only=True))
         command_parts = run_workflow_config.command
         command_parts.extend(["--tmp-outdir-prefix", Paths.TMPOUT_DATA + "/",
-                              "--outdir", Paths.OUTPUT_RESULTS_DIR + "/"])
+                              "--outdir", Paths.OUTPUT_RESULTS_DIR + "/",
+                              "--max-ram", self.job.job_flavor_memory,
+                              "--max-cores", str(self.job.job_flavor_cpus)
+                              ])
         command_parts.extend([
             self.names.workflow_path,
             self.names.job_order_path,

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import Mock, call
+from unittest.mock import Mock, call, create_autospec
 from lando.k8s.jobmanager import JobManager, JobStepTypes, Names, StageDataConfig, RunWorkflowConfig, \
     OrganizeOutputConfig, SaveOutputConfig, RecordOutputProjectConfig
 import json
@@ -10,7 +10,13 @@ class TestJobManager(TestCase):
         mock_job_order = {
             'threads': 2
         }
-        self.mock_job = Mock(username='jpb', workflow=Mock(url='someurl', job_order=mock_job_order), volume_size=3)
+        self.mock_job = Mock(
+            username='jpb',
+            workflow=Mock(url='someurl', job_order=mock_job_order),
+            volume_size=3,
+            job_flavor_cpus=2,
+            job_flavor_memory='1G',
+        )
         self.mock_job.id = '51'
         self.mock_job.vm_settings = None
         self.mock_job.k8s_settings.stage_data = Mock(
@@ -184,14 +190,14 @@ class TestJobManager(TestCase):
         self.assertEqual(job_container.name, 'run-workflow-51-jpb')  # container name
         self.assertEqual(job_container.image_name, self.mock_job.k8s_settings.run_workflow.image_name,
                          'run workflow image name is based on job settings')
-
-        self.assertEqual(job_container.command, ['bash', '-c', 'cwltool --tmp-outdir-prefix /bespin/tmpout/ '
-                                                               '--outdir /bespin/output-data/results/ '
-                                                               '/bespin/job-data/workflow/someurl '
-                                                               '/bespin/job-data/job-order.json '
-                                                               '>/bespin/output-data/bespin-workflow-output.json '
-                                                               '2>/bespin/output-data/bespin-workflow-output.log'
-                                                ],
+        expected_bash_command = 'cwltool --tmp-outdir-prefix /bespin/tmpout/ ' \
+                                '--outdir /bespin/output-data/results/ ' \
+                                '--max-ram 1G --max-cores 2 ' \
+                                '/bespin/job-data/workflow/someurl ' \
+                                '/bespin/job-data/job-order.json ' \
+                                '>/bespin/output-data/bespin-workflow-output.json ' \
+                                '2>/bespin/output-data/bespin-workflow-output.log'
+        self.assertEqual(job_container.command, ['bash', '-c', expected_bash_command],
                          'run workflow command combines job settings and staged files')
         self.assertEqual(job_container.env_dict['CALRISSIAN_POD_NAME'].field_path, 'metadata.name',
                          'We should store the pod name in a CALRISSIAN_POD_NAME environment variable')

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import Mock, call, create_autospec
+from unittest.mock import Mock, call
 from lando.k8s.jobmanager import JobManager, JobStepTypes, Names, StageDataConfig, RunWorkflowConfig, \
     OrganizeOutputConfig, SaveOutputConfig, RecordOutputProjectConfig
 import json

--- a/lando/server/jobapi.py
+++ b/lando/server/jobapi.py
@@ -302,6 +302,8 @@ class Job(object):
         self.state = data['state']
         self.step = data['step']
         self.job_flavor_name = data['job_flavor']['name']
+        self.job_flavor_cpus = data['job_flavor']['cpus']
+        self.job_flavor_memory = data['job_flavor']['memory']
         self.vm_instance_name = data['vm_instance_name']
         self.vm_volume_name = data['vm_volume_name']
         self.stage_group = data['stage_group']

--- a/lando/server/tests/test_jobapi.py
+++ b/lando/server/tests/test_jobapi.py
@@ -78,6 +78,8 @@ class TestJobApi(TestCase):
         self.assertEqual('joe@joe.com', job.username)
         self.assertEqual('N', job.state)
         self.assertEqual('m1.tiny', job.job_flavor_name)
+        self.assertEqual(1, job.job_flavor_cpus)
+        self.assertEqual('200MB', job.job_flavor_memory)
         self.assertEqual('', job.vm_instance_name)
         self.assertEqual('', job.vm_volume_name)
         self.assertEqual(True, job.cleanup_vm)

--- a/lando/server/tests/test_jobapi.py
+++ b/lando/server/tests/test_jobapi.py
@@ -23,6 +23,8 @@ class TestJobApi(TestCase):
             'created': '2017-03-21T13:29:09.123603Z',
             'job_flavor': {
                 'name': 'm1.tiny',
+                'cpus': 1,
+                'memory': '200MB',
             },
             'vm_instance_name': '',
             'vm_volume_name': '',
@@ -180,6 +182,8 @@ class TestJobApi(TestCase):
             'step': '',
             'job_flavor': {
                 'name': 'm1.tiny',
+                'cpus': 8,
+                'memory': '1G',
             },
             'vm_instance_name': '',
             'vm_volume_name': '',
@@ -246,6 +250,8 @@ class TestJobApi(TestCase):
                 'created': '2017-03-21T13:29:09.123603Z',
                 'job_flavor': {
                     'name': 'm1.tiny',
+                    'cpus': 2,
+                    'memory': '1G',
                 },
                 'vm_instance_name': '',
                 'vm_volume_name': '',
@@ -396,6 +402,8 @@ class TestJob(TestCase):
             'created': '2017-03-21T13:29:09.123603Z',
             'job_flavor': {
                 'name': 'm1.tiny',
+                'cpus': 1,
+                'memory': '200MB',
             },
             'vm_instance_name': '',
             'vm_volume_name': '',
@@ -432,7 +440,7 @@ class TestJob(TestCase):
             ],
             "cwl_pre_process_command": [
                 "prep.sh"
-            ]
+            ],
         }
         self.k8s_job_data = copy.deepcopy(job_data)
         self.k8s_job_data['job_settings']['name'] = 'k8s'


### PR DESCRIPTION
When running the workflow pass the memory and cores values from job flavor to `--max-ram` and `--max-cores`.

Requires https://github.com/Duke-GCB/calrissian/issues/52
Fixes #158