### PR TITLE
k8s job should record provenance data

### DIFF
--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -406,11 +406,11 @@ class Names(object):
         self.output_project_name = 'Bespin-job-{}-results'.format(job_id)
         self.workflow_path = '{}/{}'.format(Paths.WORKFLOW, os.path.basename(job.workflow.url))
         self.job_order_path = '{}/job-order.json'.format(Paths.JOB_DATA)
+        self.workflow_input_files_metadata_path = '{}/workflow-input-files-metadata.json'.format(Paths.JOB_DATA)
         self.system_data = 'system-data-{}'.format(suffix)
         self.run_workflow_stdout_path = '{}/bespin-workflow-output.json'.format(Paths.OUTPUT_DATA)
         self.run_workflow_stderr_path = '{}/bespin-workflow-output.log'.format(Paths.OUTPUT_DATA)
         self.annotate_project_details_path = '{}/annotate_project_details.sh'.format(Paths.OUTPUT_DATA)
-        self.workflow_input_files_metadata_path = '{}/workflow-input-files-metadata.json'.format(Paths.OUTPUT_DATA)
 
 
 class Paths(object):

--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -102,7 +102,7 @@ class JobManager(object):
             name=self.names.stage_data,
             image_name=stage_data_config.image_name,
             command=stage_data_config.command,
-            args=[stage_data_config.path],
+            args=[stage_data_config.path, self.names.workflow_input_files_metadata_path],
             env_dict=stage_data_config.env_dict,
             requested_cpu=stage_data_config.requested_cpu,
             requested_memory=stage_data_config.requested_memory,
@@ -258,7 +258,9 @@ class JobManager(object):
         save_output_config = SaveOutputConfig(self.job, self.config)
         self._create_save_output_config_map(name=self.names.save_output,
                                             filename=save_output_config.filename,
-                                            share_dds_ids=share_dds_ids)
+                                            share_dds_ids=share_dds_ids,
+                                            activity_name=save_output_config.activity_name,
+                                            activity_description=save_output_config.activity_description)
         volumes = [
             PersistentClaimVolume(self.names.job_data,
                                   mount_path=Paths.JOB_DATA,
@@ -293,13 +295,21 @@ class JobManager(object):
                                 labels=labels)
         return self.cluster_api.create_job(self.names.save_output, job_spec, labels=labels)
 
-    def _create_save_output_config_map(self, name, filename, share_dds_ids):
+    def _create_save_output_config_map(self, name, filename, share_dds_ids, activity_name, activity_description):
         config_data = {
             "destination": self.names.output_project_name,
             "readme_file_path": Paths.REMOTE_README_FILE_PATH,
             "paths": [Paths.OUTPUT_RESULTS_DIR],
             "share": {
                 "dds_user_ids": share_dds_ids
+            },
+            "activity": {
+                "name": activity_name,
+                "description": activity_description,
+                "started_on": "",
+                "ended_on": "",
+                "input_file_versions_json_path": self.names.workflow_input_files_metadata_path,
+                "workflow_output_json_path": self.names.run_workflow_stdout_path
             }
         }
         payload = {
@@ -400,6 +410,7 @@ class Names(object):
         self.run_workflow_stdout_path = '{}/bespin-workflow-output.json'.format(Paths.OUTPUT_DATA)
         self.run_workflow_stderr_path = '{}/bespin-workflow-output.log'.format(Paths.OUTPUT_DATA)
         self.annotate_project_details_path = '{}/annotate_project_details.sh'.format(Paths.OUTPUT_DATA)
+        self.workflow_input_files_metadata_path = '{}/workflow-input-files-metadata.json'.format(Paths.OUTPUT_DATA)
 
 
 class Paths(object):
@@ -467,6 +478,10 @@ class SaveOutputConfig(object):
         self.command = job_save_output_settings.base_command
         self.requested_cpu = job_save_output_settings.cpus
         self.requested_memory = job_save_output_settings.memory
+
+        self.activity_name = "{} - Bespin Job {}".format(job.name, job.id)
+        self.activity_description = "Bespin Job {} - Workflow {} v{}".format(
+            job.id, job.workflow.name, job.workflow.version)
 
 
 class RecordOutputProjectConfig(object):

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -16,8 +16,6 @@ class TestJobManager(TestCase):
             volume_size=3,
             job_flavor_cpus=2,
             job_flavor_memory='1G',
-            created='',
-            last_updated='',
         )
         self.mock_job.name = "myjob"
         self.mock_job.workflow.name = "myworkflow"

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -12,11 +12,15 @@ class TestJobManager(TestCase):
         }
         self.mock_job = Mock(
             username='jpb',
-            workflow=Mock(url='someurl', job_order=mock_job_order),
+            workflow=Mock(url='someurl', job_order=mock_job_order, version=1),
             volume_size=3,
             job_flavor_cpus=2,
             job_flavor_memory='1G',
+            created='',
+            last_updated='',
         )
+        self.mock_job.name = "myjob"
+        self.mock_job.workflow.name = "myworkflow"
         self.mock_job.id = '51'
         self.mock_job.vm_settings = None
         self.mock_job.k8s_settings.stage_data = Mock(
@@ -117,7 +121,8 @@ class TestJobManager(TestCase):
                          'stage data image name is based on a job setting')
         self.assertEqual(job_container.command, self.mock_job.k8s_settings.stage_data.base_command,
                          'stage data command is based on a job setting')
-        self.assertEqual(job_container.args, ['/bespin/config/stagedata.json'],
+        self.assertEqual(job_container.args, ['/bespin/config/stagedata.json',
+                                              '/bespin/output-data/workflow-input-files-metadata.json'],
                          'stage data command should receive config file as an argument')
         self.assertEqual(job_container.env_dict, {'DDSCLIENT_CONF': '/etc/ddsclient/config'},
                          'DukeDS environment variable should point to the config mapped config file')
@@ -341,9 +346,18 @@ class TestJobManager(TestCase):
                 "destination": "Bespin-job-51-results",
                 "readme_file_path": "results/docs/README.md",
                 "paths": ["/bespin/output-data/results"],
-                "share": {"dds_user_ids": ["123", "456"]}
+                "share": {"dds_user_ids": ["123", "456"]},
+                "activity": {
+                    "name": "myjob - Bespin Job 51",
+                    "description": "Bespin Job 51 - Workflow myworkflow v1",
+                    "started_on": "",
+                    "ended_on": "",
+                    "input_file_versions_json_path": "/bespin/output-data/workflow-input-files-metadata.json",
+                    "workflow_output_json_path": "/bespin/output-data/bespin-workflow-output.json"
+                }
             })
         }
+
         mock_cluster_api.create_config_map.assert_called_with(name='save-output-51-jpb',
                                                               data=config_map_payload,
                                                               labels=self.expected_metadata_labels)

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -120,7 +120,7 @@ class TestJobManager(TestCase):
         self.assertEqual(job_container.command, self.mock_job.k8s_settings.stage_data.base_command,
                          'stage data command is based on a job setting')
         self.assertEqual(job_container.args, ['/bespin/config/stagedata.json',
-                                              '/bespin/output-data/workflow-input-files-metadata.json'],
+                                              '/bespin/job-data/workflow-input-files-metadata.json'],
                          'stage data command should receive config file as an argument')
         self.assertEqual(job_container.env_dict, {'DDSCLIENT_CONF': '/etc/ddsclient/config'},
                          'DukeDS environment variable should point to the config mapped config file')
@@ -350,7 +350,7 @@ class TestJobManager(TestCase):
                     "description": "Bespin Job 51 - Workflow myworkflow v1",
                     "started_on": "",
                     "ended_on": "",
-                    "input_file_versions_json_path": "/bespin/output-data/workflow-input-files-metadata.json",
+                    "input_file_versions_json_path": "/bespin/job-data/workflow-input-files-metadata.json",
                     "workflow_output_json_path": "/bespin/output-data/bespin-workflow-output.json"
                 }
             })

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -355,7 +355,6 @@ class TestJobManager(TestCase):
                 }
             })
         }
-
         mock_cluster_api.create_config_map.assert_called_with(name='save-output-51-jpb',
                                                               data=config_map_payload,
                                                               labels=self.expected_metadata_labels)


### PR DESCRIPTION
Implements changes to record provenance data for k8s jobs using https://github.com/Duke-GCB/lando-util/issues/3
During the staging data step we record the downloaded files metadata into a file.
During the upload step we pass data in to specify the activity to be created.