### PR TITLE
add usage report to resulting project logs

### DIFF
--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -246,6 +246,9 @@ class JobManager(object):
             "bespin_workflow_stdout_path": self.names.run_workflow_stdout_path,
             "bespin_workflow_stderr_path": self.names.run_workflow_stderr_path,
             "methods_template": methods_document_content,
+            "additional_log_files": [
+                self.names.usage_report_path
+            ]
         }
         payload = {
             filename: json.dumps(config_data)

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -296,7 +296,8 @@ class TestJobManager(TestCase):
                         "job_order_path": "/bespin/job-data/job-order.json",
                         "bespin_workflow_stdout_path": "/bespin/output-data/bespin-workflow-output.json",
                         "bespin_workflow_stderr_path": "/bespin/output-data/bespin-workflow-output.log",
-                        "methods_template": "markdown"
+                        "methods_template": "markdown",
+                        "additional_log_files": ["/bespin/output-data/job-51-jpb-resource-usage.json"]
                     })
                 },
             labels={'bespin-job': 'true', 'bespin-job-id': '51'}


### PR DESCRIPTION
Makes use of feature added to lando-util on https://github.com/Duke-GCB/lando-util/pull/19 to include the usage report in the output logs.