### PR TITLE
k8s volume improvements

### DIFF
--- a/lando/k8s/config.py
+++ b/lando/k8s/config.py
@@ -38,7 +38,6 @@ class ServerConfig(object):
             get_or_raise_config_exception(data, 'record_output_project_settings')
         )
         self.storage_class_name = data.get('storage_class_name', None)
-        self.tmp_volume_size_in_g = data.get('tmp_volume_size_in_g', 10)
         self.base_stage_data_volume_size_in_g = data.get('base_stage_data_volume_size_in_g', 1)
 
 

--- a/lando/k8s/config.py
+++ b/lando/k8s/config.py
@@ -38,6 +38,7 @@ class ServerConfig(object):
             get_or_raise_config_exception(data, 'record_output_project_settings')
         )
         self.storage_class_name = data.get('storage_class_name', None)
+        # Controls the amount of storage reserved for storing the workflow, job order, downloaded file metadata, etc.
         self.base_stage_data_volume_size_in_g = data.get('base_stage_data_volume_size_in_g', 1)
 
 

--- a/lando/k8s/config.py
+++ b/lando/k8s/config.py
@@ -39,6 +39,7 @@ class ServerConfig(object):
         )
         self.storage_class_name = data.get('storage_class_name', None)
         self.tmp_volume_size_in_g = data.get('tmp_volume_size_in_g', 10)
+        self.base_stage_data_volume_size_in_g = data.get('base_stage_data_volume_size_in_g', 1)
 
 
 class ClusterApiSettings(object):

--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -144,10 +144,6 @@ class JobManager(object):
         run_workflow_config = RunWorkflowConfig(self.job, self.config)
         system_data_volume = run_workflow_config.system_data_volume
         volumes = [
-            PersistentClaimVolume(self.names.tmp,
-                                  mount_path=Paths.TMP,
-                                  volume_claim_name=self.names.tmp,
-                                  read_only=False),
             PersistentClaimVolume(self.names.job_data,
                                   mount_path=Paths.JOB_DATA,
                                   volume_claim_name=self.names.job_data,
@@ -155,10 +151,6 @@ class JobManager(object):
             PersistentClaimVolume(self.names.output_data,
                                   mount_path=Paths.OUTPUT_DATA,
                                   volume_claim_name=self.names.output_data,
-                                  read_only=False),
-            PersistentClaimVolume(self.names.tmpout,
-                                  mount_path=Paths.TMPOUT_DATA,
-                                  volume_claim_name=self.names.tmpout,
                                   read_only=False),
         ]
         if system_data_volume:
@@ -425,9 +417,7 @@ class Paths(object):
     STAGE_DATA_CONFIG_FILE = '/bespin/config/stagedata.json'
     OUTPUT_DATA = '/bespin/output-data'
     OUTPUT_RESULTS_DIR = '/bespin/output-data/results'
-    TMPOUT_DATA = '/bespin/tmpout'
-    TMP = '/tmp'
-    PROJECT_DETAILS_DIR = '/tmp'
+    TMPOUT_DATA = '/bespin/output-data/tmpout'
     REMOTE_README_FILE_PATH = 'results/docs/README.md'
 
 

--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -58,22 +58,6 @@ class JobManager(object):
             labels=self.default_metadata_labels,
         )
 
-    def create_tmpout_persistent_volume(self):
-        self.cluster_api.create_persistent_volume_claim(
-            self.names.tmpout,
-            storage_size_in_g=self.job.volume_size,
-            storage_class_name=self.storage_class_name,
-            labels=self.default_metadata_labels,
-        )
-
-    def create_tmp_persistent_volume(self):
-        self.cluster_api.create_persistent_volume_claim(
-            self.names.tmp,
-            storage_size_in_g=self.config.tmp_volume_size_in_g,
-            storage_class_name=self.storage_class_name,
-            labels=self.default_metadata_labels,
-        )
-
     def create_stage_data_persistent_volumes(self, stage_data_size_in_g):
         self.create_job_data_persistent_volume(stage_data_size_in_g)
 
@@ -136,9 +120,7 @@ class JobManager(object):
         self.cluster_api.delete_config_map(self.names.stage_data)
 
     def create_run_workflow_persistent_volumes(self):
-        self.create_tmpout_persistent_volume()
         self.create_output_data_persistent_volume()
-        self.create_tmp_persistent_volume()
 
     def create_run_workflow_job(self):
         run_workflow_config = RunWorkflowConfig(self.job, self.config)
@@ -189,8 +171,6 @@ class JobManager(object):
 
     def cleanup_run_workflow_job(self):
         self.cluster_api.delete_job(self.names.run_workflow)
-        self.cluster_api.delete_persistent_volume_claim(self.names.tmpout)
-        self.cluster_api.delete_persistent_volume_claim(self.names.tmp)
 
     def create_organize_output_project_job(self, methods_document_content):
         organize_output_config = OrganizeOutputConfig(self.job, self.config)

--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -42,10 +42,10 @@ class JobManager(object):
         labels[JobLabels.STEP_TYPE] = job_step_type
         return labels
 
-    def create_job_data_persistent_volume(self):
+    def create_job_data_persistent_volume(self, stage_data_size_in_g):
         self.cluster_api.create_persistent_volume_claim(
             self.names.job_data,
-            storage_size_in_g=self.job.volume_size,
+            storage_size_in_g=stage_data_size_in_g,
             storage_class_name=self.storage_class_name,
             labels=self.default_metadata_labels,
         )
@@ -74,8 +74,8 @@ class JobManager(object):
             labels=self.default_metadata_labels,
         )
 
-    def create_stage_data_persistent_volumes(self):
-        self.create_job_data_persistent_volume()
+    def create_stage_data_persistent_volumes(self, stage_data_size_in_g):
+        self.create_job_data_persistent_volume(stage_data_size_in_g)
 
     def create_stage_data_job(self, input_files):
         stage_data_config = StageDataConfig(self.job, self.config)

--- a/lando/k8s/tests/test_config.py
+++ b/lando/k8s/tests/test_config.py
@@ -63,6 +63,7 @@ FULL_CONFIG = {
         'service_account_name': 'annotation-writer-sa',
     },
     'storage_class_name': 'gluster',
+    'base_stage_data_volume_size_in_g': 3
 }
 
 
@@ -96,6 +97,7 @@ class TestServerConfig(TestCase):
         self.assertEqual(config.record_output_project_settings.service_account_name, 'annotation-writer-sa')
 
         self.assertEqual(config.storage_class_name, None)
+        self.assertEqual(config.base_stage_data_volume_size_in_g, 1)
 
     def test_optional_config(self):
         config = ServerConfig(FULL_CONFIG)
@@ -103,3 +105,4 @@ class TestServerConfig(TestCase):
         self.assertEqual(config.run_workflow_settings.system_data_volume.mount_path, '/system/data')
         self.assertEqual(config.run_workflow_settings.system_data_volume.volume_claim_name, 'system-data')
         self.assertEqual(config.cluster_api_settings.verify_ssl, False)
+        self.assertEqual(config.base_stage_data_volume_size_in_g, 3)

--- a/lando/k8s/tests/test_config.py
+++ b/lando/k8s/tests/test_config.py
@@ -63,7 +63,6 @@ FULL_CONFIG = {
         'service_account_name': 'annotation-writer-sa',
     },
     'storage_class_name': 'gluster',
-    'tmp_volume_size_in_g': 20
 }
 
 
@@ -97,7 +96,6 @@ class TestServerConfig(TestCase):
         self.assertEqual(config.record_output_project_settings.service_account_name, 'annotation-writer-sa')
 
         self.assertEqual(config.storage_class_name, None)
-        self.assertEqual(config.tmp_volume_size_in_g, 10)
 
     def test_optional_config(self):
         config = ServerConfig(FULL_CONFIG)
@@ -105,4 +103,3 @@ class TestServerConfig(TestCase):
         self.assertEqual(config.run_workflow_settings.system_data_volume.mount_path, '/system/data')
         self.assertEqual(config.run_workflow_settings.system_data_volume.volume_claim_name, 'system-data')
         self.assertEqual(config.cluster_api_settings.verify_ssl, False)
-        self.assertEqual(config.tmp_volume_size_in_g, 20)

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -162,7 +162,7 @@ class TestJobManager(TestCase):
 
     def test_create_run_workflow_persistent_volumes(self):
         mock_cluster_api = Mock()
-        mock_config = Mock(storage_class_name='nfs', tmp_volume_size_in_g=10)
+        mock_config = Mock(storage_class_name='nfs')
         manager = JobManager(cluster_api=mock_cluster_api, config=mock_config, job=self.mock_job)
 
         manager.create_run_workflow_persistent_volumes()

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -167,14 +167,8 @@ class TestJobManager(TestCase):
 
         manager.create_run_workflow_persistent_volumes()
 
-        mock_cluster_api.create_persistent_volume_claim.assert_has_calls([
-            call('tmpout-51-jpb', storage_class_name='nfs', storage_size_in_g=3,
-                 labels=self.expected_metadata_labels),
-            call('output-data-51-jpb', storage_class_name='nfs', storage_size_in_g=3,
-                 labels=self.expected_metadata_labels),
-            call('tmp-51-jpb', storage_class_name='nfs', storage_size_in_g=10,
-                 labels=self.expected_metadata_labels),
-        ])
+        mock_cluster_api.create_persistent_volume_claim.assert_called_with(
+            'output-data-51-jpb', storage_class_name='nfs', storage_size_in_g=3, labels=self.expected_metadata_labels)
 
     def test_create_run_workflow_job(self):
         mock_cluster_api = Mock()
@@ -244,9 +238,7 @@ class TestJobManager(TestCase):
         manager.cleanup_run_workflow_job()
 
         mock_cluster_api.delete_job.assert_called_with('run-workflow-51-jpb')
-        mock_cluster_api.delete_persistent_volume_claim.assert_has_calls([
-            call('tmpout-51-jpb'), call('tmp-51-jpb')
-        ], 'delete tmp volumes once running workflow completes')
+        mock_cluster_api.delete_persistent_volume_claim.assert_not_called()
 
     def test_create_organize_output_project_job(self):
         mock_cluster_api = Mock()

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -64,11 +64,11 @@ class TestJobManager(TestCase):
 
     def test_create_stage_data_persistent_volumes(self):
         manager = JobManager(cluster_api=Mock(), config=Mock(), job=self.mock_job)
-        manager.create_stage_data_persistent_volumes()
+        manager.create_stage_data_persistent_volumes(stage_data_size_in_g=10)
         manager.cluster_api.create_persistent_volume_claim.assert_has_calls([
             call('job-data-51-jpb',
                  storage_class_name=manager.storage_class_name,
-                 storage_size_in_g=3,
+                 storage_size_in_g=10,
                  labels=self.expected_metadata_labels)
         ])
 

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -194,7 +194,7 @@ class TestJobManager(TestCase):
         self.assertEqual(job_container.name, 'run-workflow-51-jpb')  # container name
         self.assertEqual(job_container.image_name, self.mock_job.k8s_settings.run_workflow.image_name,
                          'run workflow image name is based on job settings')
-        expected_bash_command = 'cwltool --tmp-outdir-prefix /bespin/tmpout/ ' \
+        expected_bash_command = 'cwltool --tmp-outdir-prefix /bespin/output-data/tmpout/ ' \
                                 '--outdir /bespin/output-data/results/ ' \
                                 '--max-ram 1G --max-cores 2 ' \
                                 '--usage-report /bespin/output-data/job-51-jpb-resource-usage.json ' \
@@ -211,33 +211,21 @@ class TestJobManager(TestCase):
         self.assertEqual(job_container.requested_memory, self.mock_job.k8s_settings.run_workflow.memory,
                          'run workflow requested memory is based on a job setting')
 
-        self.assertEqual(len(job_container.volumes), 5)
+        self.assertEqual(len(job_container.volumes), 3)
 
-        tmp_volume = job_container.volumes[0]
-        self.assertEqual(tmp_volume.name, 'tmp-51-jpb')
-        self.assertEqual(tmp_volume.mount_path, '/tmp')
-        self.assertEqual(tmp_volume.volume_claim_name, 'tmp-51-jpb')
-        self.assertEqual(tmp_volume.read_only, False)
-
-        job_data_volume = job_container.volumes[1]
+        job_data_volume = job_container.volumes[0]
         self.assertEqual(job_data_volume.name, 'job-data-51-jpb')
         self.assertEqual(job_data_volume.mount_path, '/bespin/job-data')
         self.assertEqual(job_data_volume.volume_claim_name, 'job-data-51-jpb')
         self.assertEqual(job_data_volume.read_only, True, 'job data should be a read only volume')
 
-        output_data_volume = job_container.volumes[2]
+        output_data_volume = job_container.volumes[1]
         self.assertEqual(output_data_volume.name, 'output-data-51-jpb')
         self.assertEqual(output_data_volume.mount_path, '/bespin/output-data')
         self.assertEqual(output_data_volume.volume_claim_name, 'output-data-51-jpb')
         self.assertEqual(output_data_volume.read_only, False)
 
-        tmpout_volume = job_container.volumes[3]
-        self.assertEqual(tmpout_volume.name, 'tmpout-51-jpb')
-        self.assertEqual(tmpout_volume.mount_path, '/bespin/tmpout')
-        self.assertEqual(tmpout_volume.volume_claim_name, 'tmpout-51-jpb')
-        self.assertEqual(tmpout_volume.read_only, False)
-
-        system_data_volume = job_container.volumes[4]
+        system_data_volume = job_container.volumes[2]
         self.assertEqual(system_data_volume.name, 'system-data-51-jpb')
         self.assertEqual(system_data_volume.mount_path,
                          mock_config.run_workflow_settings.system_data_volume.mount_path,

--- a/lando/server/jobapi.py
+++ b/lando/server/jobapi.py
@@ -397,6 +397,7 @@ class DukeDSFile(object):
         self.file_id = data['file_id']
         self.destination_path = data['destination_path']
         self.user_id = data['dds_user_credentials']
+        self.size = data['size']
 
 
 class URLFile(object):
@@ -409,6 +410,7 @@ class URLFile(object):
         """
         self.url = data['url']
         self.destination_path = data['destination_path']
+        self.size = data['size']
 
 
 class Credentials(object):

--- a/lando/server/tests/test_jobapi.py
+++ b/lando/server/tests/test_jobapi.py
@@ -138,12 +138,14 @@ class TestJobApi(TestCase):
                         'file_id': 123,
                         'destination_path': 'seq1.fasta',
                         'dds_user_credentials': 823,
+                        'size': 1234,
                     }
                 ],
                 'url_files': [
                     {
                         'url': "https://stuff.com/file123.model",
                         'destination_path': "file123.model",
+                        'size': 5678,
                     }
                 ],
         }
@@ -165,10 +167,12 @@ class TestJobApi(TestCase):
         self.assertEqual(123, dds_file.file_id)
         self.assertEqual('seq1.fasta', dds_file.destination_path)
         self.assertEqual(823, dds_file.user_id)
+        self.assertEqual(1234, dds_file.size)
         self.assertEqual(1, len(files.url_files))
         url_file = files.url_files[0]
         self.assertEqual('https://stuff.com/file123.model', url_file.url)
         self.assertEqual('file123.model', url_file.destination_path)
+        self.assertEqual(5678, url_file.size)
 
     def test_get_credentials(self, mock_requests, mock_k8s_settings, mock_vm_settings):
         """


### PR DESCRIPTION
Determines size of the job-data volume based on the size of the input data + a config setting base size. The setting base size is a new config file setting called `base_stage_data_volume_size_in_g `.

Removes the tmp and tmpout volumes. The workflow runner job will now be provided a single ouput-data volume and flags to use directories inside that volume for output data and tmpout.
The tmpout directory will now be `/bespin/output-data/tmpout`.

Fixes #141 