### PR TITLE
fix job input data gb conversion

### DIFF
--- a/lando/k8s/lando.py
+++ b/lando/k8s/lando.py
@@ -61,7 +61,7 @@ class K8sJobActions(BaseJobActions):
             total_bytes += dds_file.size
         for url_file in input_files.url_files:
             total_bytes += url_file.size
-        return math.ceil(float(total_bytes) / (1024.0 * 1024.0))
+        return math.ceil(float(total_bytes) / (1024.0 * 1024.0 * 1024.0))
 
     def perform_staging_step(self, input_files):
         self._set_job_step(JobSteps.STAGING)

--- a/lando/k8s/tests/test_lando.py
+++ b/lando/k8s/tests/test_lando.py
@@ -60,13 +60,13 @@ class TestK8sJobActions(TestCase):
                 'dds_files': [{
                     'file_id': '123',
                     'destination_path': '/somepath/123.dat',
-                    'size': 3 * 1024 * 1024,
+                    'size': 3 * 1024 * 1024 * 1024,  # 3 GiB
                     'dds_user_credentials': {}
                 }],
                 'url_files': [{
                     'url': 'someurl',
                     'destination_path': '/somepath/456.dat',
-                    'size': 1 * 1024 * 1024,
+                    'size': 1 * 1024 * 1024 * 1024,  # 1 GiB
                 }]
             }
         )


### PR DESCRIPTION
Previously the code was converting bytes to MiB instead of GiB.
This resulted in enormous job data volumes.
Fixes #177 