### PR TITLE
Fix job cancellation

### DIFF
--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -35,7 +35,8 @@ class JobManager(object):
             JobLabels.BESPIN_JOB: BESPIN_JOB_LABEL_VALUE,
             JobLabels.JOB_ID: str(self.job.id),
         }
-        self.label_selector = '{}={}'.format(JobLabels.BESPIN_JOB, BESPIN_JOB_LABEL_VALUE)
+        label_ary = ['{}={}'.format(k,v) for k,v in self.default_metadata_labels.items()]
+        self.label_selector = ','.join(label_ary)
 
     def make_job_labels(self, job_step_type):
         labels = dict(self.default_metadata_labels)

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -449,6 +449,8 @@ class TestJobManager(TestCase):
 
         self.assertEqual(project_id, '123')
         self.assertEqual(readme_file_id, '456')
+        mock_cluster_api.list_pods.assert_called_with(
+            label_selector='bespin-job=true,bespin-job-id=51,bespin-job-step=record_output_project')
 
     def test_read_record_output_project_details_pod_not_found(self):
         mock_cluster_api = Mock()

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -497,15 +497,15 @@ class TestJobManager(TestCase):
         ])
 
     def test_cleanup_all(self):
-        mock_job = Mock()
-        mock_job.metadata.name = 'job_1'
+        self.mock_job.id = 1
+        self.mock_job.metadata.name = 'job_1'
         mock_config_map = Mock()
         mock_config_map.metadata.name = 'config_map_1'
         mock_pvc = Mock()
         mock_pvc.metadata.name = 'pvc_1'
 
         mock_cluster_api = Mock()
-        mock_cluster_api.list_jobs.return_value = [mock_job]
+        mock_cluster_api.list_jobs.return_value = [self.mock_job]
         mock_cluster_api.list_config_maps.return_value = [mock_config_map]
         mock_cluster_api.list_persistent_volume_claims.return_value = [mock_pvc]
         mock_config = Mock(storage_class_name='nfs')
@@ -516,6 +516,13 @@ class TestJobManager(TestCase):
         mock_cluster_api.delete_job.assert_called_with('job_1')
         mock_cluster_api.delete_config_map.assert_called_with('config_map_1')
         mock_cluster_api.delete_persistent_volume_claim.assert_called_with('pvc_1')
+
+        mock_cluster_api.list_persistent_volume_claims.assert_called_with(
+            label_selector='bespin-job=true,bespin-job-id=1')
+        mock_cluster_api.list_jobs.assert_called_with(
+            label_selector='bespin-job=true,bespin-job-id=1')
+        mock_cluster_api.list_config_maps.assert_called_with(
+            label_selector='bespin-job=true,bespin-job-id=1')
 
 
 class TestNames(TestCase):


### PR DESCRIPTION
Canceling one k8s job canceled all k8s jobs.
This was due to a label selector that was missing the job id.

Tested these changes on dev. I was able to cancel a job without effecting another running job.

Fixes #176 
