### PR TITLE
Upload releases to PyPI, verify version matches tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
           key: deps-{{ .Branch }}-{{ checksum "setup.py" }}-{{ checksum "devRequirements.txt" }}
       - run:
           command: |
-            virtualenv venv
+            python3 -m venv venv
             source venv/bin/activate
             pip install -r devRequirements.txt
             python setup.py install
@@ -26,3 +26,49 @@ jobs:
       - store_artifacts:
           path: test-results
           destination: tr1
+  deploy:
+    docker:
+      - image: circleci/python:3.6
+    steps:
+      - checkout
+      - restore_cache:
+          key: v1-setup-cache-{{ checksum "setup.py" }}
+      - run:
+          name: install python dependencies
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            python setup.py install
+            pip install twine
+            pip install wheel
+      - save_cache:
+          key: v1-setup-cache-{{ checksum "setup.py" }}
+          paths:
+            - "venv"
+      - run:
+          name: verify git tag vs. version
+          command: |
+            python3 -m venv venv
+            . venv/bin/activate
+            python setup.py verify
+      - run:
+          name: create packages
+          command: |
+            . venv/bin/activate
+            python setup.py bdist_wheel --universal
+workflows:
+  version: 2
+  build_and_deploy:
+    jobs:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+      - deploy:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /[0-9]+(\.[0-9]+)*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,17 @@ jobs:
           command: |
             . venv/bin/activate
             python setup.py bdist_wheel --universal
+      - run:
+          name: init .pypirc
+          command: |
+            echo -e "[pypi]" >> ~/.pypirc
+            echo -e "username = $PYPI_USER" >> ~/.pypirc
+            echo -e "password = $PYPI_PASSWORD" >> ~/.pypirc
+      - run:
+          name: upload to pypi
+          command: |
+            . venv/bin/activate
+            twine upload dist/*
 workflows:
   version: 2
   build_and_deploy:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,11 @@
+import os
+import sys
 from setuptools import setup, find_packages
+# version checking derived from https://github.com/levlaz/circleci.py/blob/master/setup.py
+from setuptools.command.install import install
+
+VERSION = '0.9.14'
+TAG_ENV_VAR = 'CIRCLE_TAG'
 
 
 LANDO_REQUIREMENTS = [
@@ -16,8 +23,23 @@ LANDO_REQUIREMENTS = [
       "requests==2.20.1",
 ]
 
+
+class VerifyVersionCommand(install):
+    """Custom command to verify that the git tag matches our version"""
+    description = 'verify that the git tag matches our version'
+
+    def run(self):
+        tag = os.getenv(TAG_ENV_VAR)
+
+        if tag != VERSION:
+            info = "Git tag: {0} does not match the version of this app: {1}".format(
+                tag, VERSION
+            )
+            sys.exit(info)
+
+
 setup(name='lando',
-      version='0.9.14',
+      version=VERSION,
       description='Cloud based bioinformatics workflow runner',
       url='https://github.com/Duke-GCB/lando',
       author='Dan Leehr, John Bradley',
@@ -32,6 +54,9 @@ setup(name='lando',
                   'lando_worker = lando.worker.__main__:main',
                   'lando_client = lando.client.__main__:main',
             ]
-      }
-      )
+      },
+      cmdclass={
+          'verify': VerifyVersionCommand,
+      },
+)
 


### PR DESCRIPTION
- Updates CircleCI config to build+deploy, verified in a [fork](https://github.com/dleehr/lando)
- Deploy includes code to verify version in setup.py matches the tag being released
- Deploy uploads `lando` to PyPI. I manually uploaded 0.9.14 from a local build off the tag
- After merging this and other changes today, we can tag/release 0.9.15

Fixes #179 