### PR TITLE
upgrade DukeDSClient for s3 support

### DIFF
--- a/lando/server/tests/test_cloudconfigscript.py
+++ b/lando/server/tests/test_cloudconfigscript.py
@@ -2,6 +2,7 @@
 from unittest import TestCase
 from lando.server.cloudconfigscript import CloudConfigScript
 
+
 class TestCloudConfigScript(TestCase):
 
     def test_write_file(self):
@@ -11,7 +12,8 @@ class TestCloudConfigScript(TestCase):
         expected = """#cloud-config
 
 write_files:
-- {content: file-content, path: /etc/config.yml}
+- content: file-content
+  path: /etc/config.yml
 """
         c.add_write_file(file_content, path)
         self.assertMultiLineEqual(expected, c.content)
@@ -22,11 +24,15 @@ write_files:
         expected = """#cloud-config
 
 disk_setup:
-  /dev/vdg: {layout: true, table_type: gpt}
+  /dev/vdg:
+    layout: true
+    table_type: gpt
 fs_setup:
-- {device: /dev/vdg1, filesystem: ext3}
+- device: /dev/vdg1
+  filesystem: ext3
 mounts:
-- [/dev/vdg1, /mnt/data]
+- - /dev/vdg1
+  - /mnt/data
 """
         self.assertMultiLineEqual(expected, c.content)
 
@@ -35,6 +41,6 @@ mounts:
         c.add_manage_etc_hosts()
         expected = """#cloud-config
 
-{manage_etc_hosts: localhost}
+manage_etc_hosts: localhost
 """
         self.assertMultiLineEqual(expected, c.content)

--- a/lando/server/tests/test_lando.py
+++ b/lando/server/tests/test_lando.py
@@ -47,14 +47,18 @@ queue_name: task-queue
 CLOUD_CONFIG = """#cloud-config
 
 disk_setup:
-  /dev/vdb: {layout: true, table_type: gpt}
+  /dev/vdb:
+    layout: true
+    table_type: gpt
 fs_setup:
-- {device: /dev/vdb1, filesystem: ext3}
+- device: /dev/vdb1
+  filesystem: ext3
 manage_etc_hosts: localhost
 mounts:
-- [/dev/vdb1, /work]
+- - /dev/vdb1
+  - /work
 write_files:
-- {content: '
+- content: '
 
     host: 10.109.253.74
 
@@ -64,7 +68,8 @@ write_files:
 
     queue_name: task-queue
 
-    ', path: /etc/lando_worker_config.yml}
+    '
+  path: /etc/lando_worker_config.yml
 """
 
 

--- a/lando/worker/tests/test_staging.py
+++ b/lando/worker/tests/test_staging.py
@@ -74,19 +74,6 @@ class TestDukeDataService(TestCase):
                                                                 auth_role='project_admin', force_send=True,
                                                                 user_message='Bespin job results.')
 
-    @patch('lando.worker.staging.D4S2Project')
-    @patch('lando.worker.staging.RemoteStore')
-    @patch('lando.worker.staging.RemoteFile')
-    @patch('lando.worker.staging.FileDownloader')
-    @patch('lando.worker.staging.ProjectDownload')
-    def test_download_file(self, mock_project_download, mock_file_downloader, mock_remote_file, mock_remote_store,
-                           mock_d4s2_project):
-        remote_user = Mock(id='132')
-        mock_remote_store.return_value.fetch_user.return_value = remote_user
-        data_service = DukeDataService(MagicMock())
-        data_service.download_file('123', '/tmp/data.txt')
-        mock_file_downloader.return_value.run.assert_called()
-
 
 class TestProjectDetails(TestCase):
     def test_constructor(self):

--- a/setup.py
+++ b/setup.py
@@ -10,15 +10,15 @@ TAG_ENV_VAR = 'CIRCLE_TAG'
 
 LANDO_REQUIREMENTS = [
       "shade==1.29.0",
-      "DukeDSClient==1.0.3",
+      "DukeDSClient==2.1.4",
       "humanfriendly==2.4",
-      "Jinja2==2.9.5",
+      "Jinja2==2.10.1",
       "kubernetes==8.0.1",
       "pyasn1<0.5.0,>=0.4.1",
       "lando-messaging==1.0.0",
       "Markdown==2.6.9",
       "python-dateutil==2.6.0",
-      "PyYAML==3.12",
+      "PyYAML==5.1",
       "requests==2.20.1",
 ]
 


### PR DESCRIPTION
- Upgrades DukeDSClient to 2.1.4 which has support for the S3 backend.
- Changed the download logic to match [lando-util](https://github.com/Duke-GCB/lando-util/blob/8e8c8d967a82a056d85a7b0bdf51a61b5b8dd603/lando_util/download.py#L27-L28)
- Upgrades PyYAML to 5.1 since it's required by DukeDSClient. This changed a bunch of YAML in tests. In a test the cloud config script seemed to work fine.
- Upgrades Jinja2 to 2.10.1 since there is a security issue with previous version.