### PR TITLE
use correct location for finding size in dukeds file resp

### DIFF
--- a/lando/worker/staging.py
+++ b/lando/worker/staging.py
@@ -146,7 +146,7 @@ class DownloadDukeDSFile(object):
         dds_file = dds_client.get_file_by_id(self.file_id)
         logging.info("Downloading file id:{} to {}".format(self.file_id, self.dest))
         dds_file.download_to_path(self.dest)
-        FileUrlDownloader.check_file_size(dds_file.current_version['size'], self.dest)
+        FileUrlDownloader.check_file_size(dds_file.current_version['upload']['size'], self.dest)
 
 
 class DownloadURLFile(object):

--- a/lando/worker/tests/test_staging.py
+++ b/lando/worker/tests/test_staging.py
@@ -125,4 +125,4 @@ class TestDownloadDukeDSFile(TestCase):
         mock_dds_file = mock_duke_ds_client.return_value.get_file_by_id.return_value
         mock_dds_file.download_to_path.assert_called_with('/bespin/data/input.txt')
         mock_file_url_downloader.check_file_size.assert_called_with(
-            mock_dds_file.current_version['size'], '/bespin/data/input.txt')
+            mock_dds_file.current_version['upload']['size'], '/bespin/data/input.txt')


### PR DESCRIPTION
Fixes #193 
Bug introduced in #192.
> I must have accidentally tested that PR with an older bespin worker VM.