### PR TITLE
support for zipped workflows in k8s  jobs

### DIFF
--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -129,8 +129,8 @@ class JobManager(object):
         self.cluster_api.create_config_map(name=name, data=payload, labels=self.default_metadata_labels)
 
     @staticmethod
-    def _stage_data_config_item(type, source, dest, unzip_to=None):
-        item = {"type": type, "source": source, "dest": dest}
+    def _stage_data_config_item(workflow_type, source, dest, unzip_to=None):
+        item = {"type": workflow_type, "source": source, "dest": dest}
         if unzip_to:
             item["unzip_to"] = unzip_to
         return item

--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -109,7 +109,9 @@ class JobManager(object):
         ]
         if workflow_type == WorkflowTypes.ZIPPED:
             items.append(self._stage_data_config_item("unzip", self.names.workflow_download_dest, Paths.WORKFLOW))
-        elif workflow_type != WorkflowTypes.PACKED:
+        elif workflow_type == WorkflowTypes.PACKED:
+            pass
+        else:
             raise ValueError("Unknown workflow type {}".format(workflow_type))
         items.append(self._stage_data_config_item("write", workflow.job_order, self.names.job_order_path))
         for dds_file in input_files.dds_files:

--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -40,8 +40,7 @@ class JobManager(object):
         self.cluster_api = cluster_api
         self.config = config
         self.job = job
-        self.workflow_type_details = WorkflowTypeDetails(job)
-        self.names = self.workflow_type_details.names
+        self.names = create_workflow_names(job)
         self.storage_class_name = config.storage_class_name
         self.default_metadata_labels = {
             JobLabels.BESPIN_JOB: BESPIN_JOB_LABEL_VALUE,
@@ -427,15 +426,14 @@ class PackedWorkflowNames(Names):
         self.unzip_workflow_url_to_path = None
 
 
-class WorkflowTypeDetails(object):
-    def __init__(self, job):
-        workflow_type = job.workflow.workflow_type
-        if job.workflow.workflow_type == WorkflowTypes.ZIPPED:
-            self.names = ZippedWorkflowNames(job)
-        elif job.workflow.workflow_type == WorkflowTypes.PACKED:
-            self.names = PackedWorkflowNames(job)
-        else:
-            raise ValueError("Unknown workflow type {}".format(workflow_type))
+def create_workflow_names(job):
+    workflow_type = job.workflow.workflow_type
+    if workflow_type == WorkflowTypes.ZIPPED:
+        return ZippedWorkflowNames(job)
+    elif workflow_type == WorkflowTypes.PACKED:
+        return PackedWorkflowNames(job)
+    else:
+        raise ValueError("Unknown workflow type {}".format(workflow_type))
 
 
 class Paths(object):

--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -216,6 +216,7 @@ class JobManager(object):
             "bespin_job_id": self.job.id,
             "destination_dir": Paths.OUTPUT_RESULTS_DIR,
             "workflow_path": self.names.workflow_download_dest,
+            "workflow_to_read": self.names.workflow_to_read,
             "workflow_type": self.job.workflow.workflow_type,
             "job_order_path": self.names.job_order_path,
             "bespin_workflow_stdout_path": self.names.run_workflow_stdout_path,
@@ -390,10 +391,12 @@ class Names(object):
         if workflow_type == 'packed':
             # For packed workflow_type workflow_path contains object name. Typically '#main'.
             self.workflow_to_run = '{}{}'.format(self.workflow_download_dest, job.workflow.workflow_path)
+            self.workflow_to_read = self.workflow_download_dest
         elif workflow_type == 'zipped':
             # for zipped workflow_type workflow_path contains relative path to workflow within zip file
             # this zip file will be extracted into WORKFLOW directory
             self.workflow_to_run = '{}/{}'.format(Paths.WORKFLOW, job.workflow.workflow_path)
+            self.workflow_to_read = self.workflow_to_run
         else:
             raise ValueError("Unknown workflow type {}".format(workflow_type))
         self.job_order_path = '{}/job-order.json'.format(Paths.JOB_DATA)

--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -103,7 +103,7 @@ class JobManager(object):
             self._stage_data_config_item("url", workflow.workflow_url, self.names.workflow_download_dest),
         ]
         if workflow_type == 'zipped':
-            items.append("unzip", self.names.workflow_download_dest, Paths.WORKFLOW)
+            items.append(self._stage_data_config_item("unzip", self.names.workflow_download_dest, Paths.WORKFLOW))
         elif workflow_type != 'packed':
             raise ValueError("Unknown workflow type {}".format(workflow_type))
         items.append(self._stage_data_config_item("write", workflow.job_order, self.names.job_order_path))

--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -40,7 +40,7 @@ class JobManager(object):
         self.cluster_api = cluster_api
         self.config = config
         self.job = job
-        self.names = create_workflow_names(job)
+        self.names = create_names(job)
         self.storage_class_name = config.storage_class_name
         self.default_metadata_labels = {
             JobLabels.BESPIN_JOB: BESPIN_JOB_LABEL_VALUE,
@@ -426,7 +426,7 @@ class PackedWorkflowNames(Names):
         self.unzip_workflow_url_to_path = None
 
 
-def create_workflow_names(job):
+def create_names(job):
     workflow_type = job.workflow.workflow_type
     if workflow_type == WorkflowTypes.ZIPPED:
         return ZippedWorkflowNames(job)

--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -24,6 +24,11 @@ class JobStepTypes(object):
     RECORD_OUTPUT_PROJECT = "record_output_project"
 
 
+class WorkflowTypes(object):
+    ZIPPED = 'zipped'
+    PACKED = 'packed'
+
+
 class JobManager(object):
     def __init__(self, cluster_api, config, job):
         self.cluster_api = cluster_api
@@ -102,9 +107,9 @@ class JobManager(object):
         items = [
             self._stage_data_config_item("url", workflow.workflow_url, self.names.workflow_download_dest),
         ]
-        if workflow_type == 'zipped':
+        if workflow_type == WorkflowTypes.ZIPPED:
             items.append(self._stage_data_config_item("unzip", self.names.workflow_download_dest, Paths.WORKFLOW))
-        elif workflow_type != 'packed':
+        elif workflow_type != WorkflowTypes.PACKED:
             raise ValueError("Unknown workflow type {}".format(workflow_type))
         items.append(self._stage_data_config_item("write", workflow.job_order, self.names.job_order_path))
         for dds_file in input_files.dds_files:
@@ -388,11 +393,11 @@ class Names(object):
             job.workflow.name, job.workflow.version, job.name, job_created)
         self.workflow_download_dest = '{}/{}'.format(Paths.WORKFLOW, os.path.basename(job.workflow.workflow_url))
         workflow_type = job.workflow.workflow_type
-        if workflow_type == 'packed':
+        if workflow_type == WorkflowTypes.PACKED:
             # For packed workflow_type workflow_path contains object name. Typically '#main'.
             self.workflow_to_run = '{}{}'.format(self.workflow_download_dest, job.workflow.workflow_path)
             self.workflow_to_read = self.workflow_download_dest
-        elif workflow_type == 'zipped':
+        elif workflow_type == WorkflowTypes.ZIPPED:
             # for zipped workflow_type workflow_path contains relative path to workflow within zip file
             # this zip file will be extracted into WORKFLOW directory
             self.workflow_to_run = '{}/{}'.format(Paths.WORKFLOW, job.workflow.workflow_path)

--- a/lando/k8s/jobmanager.py
+++ b/lando/k8s/jobmanager.py
@@ -229,7 +229,7 @@ class JobManager(object):
         config_data = {
             "bespin_job_id": self.job.id,
             "destination_dir": Paths.OUTPUT_RESULTS_DIR,
-            "workflow_path": self.names.workflow_download_dest,
+            "downloaded_workflow_path": self.names.workflow_download_dest,
             "workflow_to_read": self.names.workflow_to_read,
             "workflow_type": self.job.workflow.workflow_type,
             "job_order_path": self.names.job_order_path,

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from unittest.mock import Mock, call
-from lando.k8s.jobmanager import JobManager, JobStepTypes, create_workflow_names, StageDataConfig, RunWorkflowConfig, \
+from lando.k8s.jobmanager import JobManager, JobStepTypes, create_names, StageDataConfig, RunWorkflowConfig, \
     OrganizeOutputConfig, SaveOutputConfig, RecordOutputProjectConfig, WorkflowTypes
 import json
 
@@ -621,7 +621,7 @@ class TestNames(TestCase):
         mock_job.name = 'myjob'
         mock_job.workflow.name = 'myworkflow'
         mock_job.id = '123'
-        names = create_workflow_names(mock_job)
+        names = create_names(mock_job)
         self.assertEqual(names.job_data, 'job-data-123-jpb')
         self.assertEqual(names.output_data, 'output-data-123-jpb')
         self.assertEqual(names.tmpout, 'tmpout-123-jpb')
@@ -652,7 +652,7 @@ class TestNames(TestCase):
         mock_job.name = 'myjob'
         mock_job.workflow.name = 'myworkflow'
         mock_job.id = '123'
-        names = create_workflow_names(mock_job)
+        names = create_names(mock_job)
         self.assertEqual(names.job_data, 'job-data-123-jpb')
         self.assertEqual(names.output_data, 'output-data-123-jpb')
         self.assertEqual(names.tmpout, 'tmpout-123-jpb')
@@ -684,7 +684,7 @@ class TestNames(TestCase):
         mock_job.workflow.name = 'myworkflow'
         mock_job.id = '123'
         with self.assertRaises(ValueError) as raised_exception:
-            create_workflow_names(mock_job)
+            create_names(mock_job)
         self.assertEqual(str(raised_exception.exception), 'Unknown workflow type faketype')
 
     def test_strips_username_after_at_sign(self):
@@ -694,7 +694,7 @@ class TestNames(TestCase):
         mock_job.name = 'myjob'
         mock_job.workflow.name = 'myworkflow'
         mock_job.id = '123'
-        names = create_workflow_names(mock_job)
+        names = create_names(mock_job)
         self.assertEqual(names.job_data, 'job-data-123-tom')
         self.assertEqual(names.output_data, 'output-data-123-tom')
         self.assertEqual(names.tmpout, 'tmpout-123-tom')

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -356,7 +356,7 @@ class TestJobManager(TestCase):
                     json.dumps({
                         "bespin_job_id": '51',
                         "destination_dir": "/bespin/output-data/results",
-                        "workflow_path": "/bespin/job-data/workflow/someurl.cwl",
+                        "downloaded_workflow_path": "/bespin/job-data/workflow/someurl.cwl",
                         "workflow_to_read": "/bespin/job-data/workflow/someurl.cwl",
                         "workflow_type": "packed",
                         "job_order_path": "/bespin/job-data/job-order.json",

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from unittest.mock import Mock, call
-from lando.k8s.jobmanager import JobManager, JobStepTypes, WorkflowTypeDetails, StageDataConfig, RunWorkflowConfig, \
+from lando.k8s.jobmanager import JobManager, JobStepTypes, create_workflow_names, StageDataConfig, RunWorkflowConfig, \
     OrganizeOutputConfig, SaveOutputConfig, RecordOutputProjectConfig, WorkflowTypes
 import json
 
@@ -613,7 +613,7 @@ class TestJobManager(TestCase):
             label_selector='bespin-job=true,bespin-job-id=1')
 
 
-class TestWorkflowTypeDetails(TestCase):
+class TestNames(TestCase):
     def test_constructor_packed(self):
         mock_job = Mock(username='jpb', created='2019-03-11T12:30',
                         workflow=Mock(workflow_url='https://somewhere.com/someworkflow.cwl', version=1,
@@ -621,8 +621,7 @@ class TestWorkflowTypeDetails(TestCase):
         mock_job.name = 'myjob'
         mock_job.workflow.name = 'myworkflow'
         mock_job.id = '123'
-        details = WorkflowTypeDetails(mock_job)
-        names = details.names
+        names = create_workflow_names(mock_job)
         self.assertEqual(names.job_data, 'job-data-123-jpb')
         self.assertEqual(names.output_data, 'output-data-123-jpb')
         self.assertEqual(names.tmpout, 'tmpout-123-jpb')
@@ -653,8 +652,7 @@ class TestWorkflowTypeDetails(TestCase):
         mock_job.name = 'myjob'
         mock_job.workflow.name = 'myworkflow'
         mock_job.id = '123'
-        details = WorkflowTypeDetails(mock_job)
-        names = details.names
+        names = create_workflow_names(mock_job)
         self.assertEqual(names.job_data, 'job-data-123-jpb')
         self.assertEqual(names.output_data, 'output-data-123-jpb')
         self.assertEqual(names.tmpout, 'tmpout-123-jpb')
@@ -686,8 +684,7 @@ class TestWorkflowTypeDetails(TestCase):
         mock_job.workflow.name = 'myworkflow'
         mock_job.id = '123'
         with self.assertRaises(ValueError) as raised_exception:
-            details = WorkflowTypeDetails(mock_job)
-            names = details.names
+            create_workflow_names(mock_job)
         self.assertEqual(str(raised_exception.exception), 'Unknown workflow type faketype')
 
     def test_strips_username_after_at_sign(self):
@@ -697,8 +694,7 @@ class TestWorkflowTypeDetails(TestCase):
         mock_job.name = 'myjob'
         mock_job.workflow.name = 'myworkflow'
         mock_job.id = '123'
-        details = WorkflowTypeDetails(mock_job)
-        names = details.names
+        names = create_workflow_names(mock_job)
         self.assertEqual(names.job_data, 'job-data-123-tom')
         self.assertEqual(names.output_data, 'output-data-123-tom')
         self.assertEqual(names.tmpout, 'tmpout-123-tom')

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -274,6 +274,7 @@ class TestJobManager(TestCase):
                         "bespin_job_id": '51',
                         "destination_dir": "/bespin/output-data/results",
                         "workflow_path": "/bespin/job-data/workflow/someurl.cwl",
+                        "workflow_to_read": "/bespin/job-data/workflow/someurl.cwl",
                         "workflow_type": "packed",
                         "job_order_path": "/bespin/job-data/job-order.json",
                         "bespin_workflow_stdout_path": "/bespin/output-data/bespin-workflow-output.json",

--- a/lando/k8s/tests/test_jobmanager.py
+++ b/lando/k8s/tests/test_jobmanager.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 from unittest.mock import Mock, call
-from lando.k8s.jobmanager import JobManager, JobStepTypes, Names, StageDataConfig, RunWorkflowConfig, \
+from lando.k8s.jobmanager import JobManager, JobStepTypes, WorkflowTypeDetails, StageDataConfig, RunWorkflowConfig, \
     OrganizeOutputConfig, SaveOutputConfig, RecordOutputProjectConfig, WorkflowTypes
 import json
 
@@ -171,12 +171,8 @@ class TestJobManager(TestCase):
                     {
                         "type": "url",
                         "source": "someurl.zip",
-                        "dest": "/bespin/job-data/workflow/someurl.zip"
-                    },
-                    {
-                        "type": "unzip",
-                        "source": "/bespin/job-data/workflow/someurl.zip",
-                        "dest": "/bespin/job-data/workflow"
+                        "dest": "/bespin/job-data/workflow/someurl.zip",
+                        "unzip_to": "/bespin/job-data/workflow"
                     },
                     {
                         "type": "write",
@@ -617,7 +613,7 @@ class TestJobManager(TestCase):
             label_selector='bespin-job=true,bespin-job-id=1')
 
 
-class TestNames(TestCase):
+class TestWorkflowTypeDetails(TestCase):
     def test_constructor_packed(self):
         mock_job = Mock(username='jpb', created='2019-03-11T12:30',
                         workflow=Mock(workflow_url='https://somewhere.com/someworkflow.cwl', version=1,
@@ -625,7 +621,8 @@ class TestNames(TestCase):
         mock_job.name = 'myjob'
         mock_job.workflow.name = 'myworkflow'
         mock_job.id = '123'
-        names = Names(mock_job)
+        details = WorkflowTypeDetails(mock_job)
+        names = details.names
         self.assertEqual(names.job_data, 'job-data-123-jpb')
         self.assertEqual(names.output_data, 'output-data-123-jpb')
         self.assertEqual(names.tmpout, 'tmpout-123-jpb')
@@ -656,7 +653,8 @@ class TestNames(TestCase):
         mock_job.name = 'myjob'
         mock_job.workflow.name = 'myworkflow'
         mock_job.id = '123'
-        names = Names(mock_job)
+        details = WorkflowTypeDetails(mock_job)
+        names = details.names
         self.assertEqual(names.job_data, 'job-data-123-jpb')
         self.assertEqual(names.output_data, 'output-data-123-jpb')
         self.assertEqual(names.tmpout, 'tmpout-123-jpb')
@@ -688,7 +686,8 @@ class TestNames(TestCase):
         mock_job.workflow.name = 'myworkflow'
         mock_job.id = '123'
         with self.assertRaises(ValueError) as raised_exception:
-            Names(mock_job)
+            details = WorkflowTypeDetails(mock_job)
+            names = details.names
         self.assertEqual(str(raised_exception.exception), 'Unknown workflow type faketype')
 
     def test_strips_username_after_at_sign(self):
@@ -698,7 +697,8 @@ class TestNames(TestCase):
         mock_job.name = 'myjob'
         mock_job.workflow.name = 'myworkflow'
         mock_job.id = '123'
-        names = Names(mock_job)
+        details = WorkflowTypeDetails(mock_job)
+        names = details.names
         self.assertEqual(names.job_data, 'job-data-123-tom')
         self.assertEqual(names.output_data, 'output-data-123-tom')
         self.assertEqual(names.tmpout, 'tmpout-123-tom')

--- a/lando/k8s/tests/test_lando.py
+++ b/lando/k8s/tests/test_lando.py
@@ -27,6 +27,7 @@ class TestK8sJobActions(TestCase):
                              workflow=Mock(workflow_url='someurl.cwl', version='2'))
         self.mock_job.name = 'myjob'
         self.mock_job.workflow.name = 'myworkflow'
+        self.mock_job.workflow.workflow_type = 'packed'
         self.mock_job.id = '49'
         self.mock_job.username = 'joe@joe.com'
         self.mock_job_api = self.mock_settings.get_job_api.return_value


### PR DESCRIPTION
Support for zipped workflows
- When staging a zipped workflow specify `unzip_to` option to extract the zipfile
- When organizing the output project pass `downloaded_workflow_path`, `workflow_to_read` and `workflow_type` parameters.

Fixes #188

Requires: https://github.com/Duke-GCB/lando-util/pull/21