### PR TITLE
Fix saving logs from failed jobs

### DIFF
--- a/lando/k8s/cluster.py
+++ b/lando/k8s/cluster.py
@@ -93,7 +93,8 @@ class ClusterApi(object):
         # So instead we are using the _preload_content flag and calling read() based on the following comment:
         # https://github.com/kubernetes/kubernetes/issues/37881#issuecomment-264366664
         # This changes the returned value so we must add an additional call to read()
-        return self.core.read_namespaced_pod_log(name, self.namespace, _preload_content=False).read()
+        stream = self.core.read_namespaced_pod_log(name, self.namespace, _preload_content=False)
+        return stream.read().decode("utf-8")
 
     def list_pods(self, label_selector):
         return self.core.list_namespaced_pod(self.namespace, label_selector=label_selector).items

--- a/lando/k8s/tests/test_cluster.py
+++ b/lando/k8s/tests/test_cluster.py
@@ -138,7 +138,9 @@ class TestClusterApi(TestCase):
         # Added _preload_content argument to allow fetching actual text instead of parsed
         # based on https://github.com/kubernetes/kubernetes/issues/37881#issuecomment-264366664
         resp = self.cluster_api.read_pod_logs('mypod')
-        self.assertEqual(resp, self.mock_core_api.read_namespaced_pod_log.return_value.read.return_value)
+        log_stream = self.mock_core_api.read_namespaced_pod_log.return_value
+        self.assertEqual(resp, log_stream.read.return_value.decode.return_value)
+        log_stream.read.return_value.decode.assert_called_with('utf-8')
         self.mock_core_api.read_namespaced_pod_log.assert_called_with('mypod', 'lando-job-runner',
                                                                       _preload_content=False)
 

--- a/lando/k8s/tests/test_cluster.py
+++ b/lando/k8s/tests/test_cluster.py
@@ -1,8 +1,10 @@
 from unittest import TestCase
 from unittest.mock import patch, Mock, call
 from lando.k8s.cluster import ClusterApi, AccessModes, Container, SecretVolume, SecretEnvVar, EnvVarSource, \
-    FieldRefEnvVar, VolumeBase, SecretVolume, PersistentClaimVolume, ConfigMapVolume, BatchJobSpec
+    FieldRefEnvVar, VolumeBase, SecretVolume, PersistentClaimVolume, ConfigMapVolume, BatchJobSpec, \
+    ItemNotFoundException
 from kubernetes import client
+from dateutil.parser import parse
 
 
 class TestClusterApi(TestCase):
@@ -176,6 +178,37 @@ class TestClusterApi(TestCase):
         mock_config_map_list = self.mock_core_api.list_namespaced_config_map.return_value
         self.assertEqual(resp, mock_config_map_list.items)
 
+    def test_read_job_logs(self):
+        mock_pod = Mock()
+        mock_pod.metadata.name = 'myjob-abcd'
+        self.cluster_api.get_most_recent_pod_for_job = Mock()
+        self.cluster_api.get_most_recent_pod_for_job.return_value = mock_pod
+        self.cluster_api.read_pod_logs = Mock()
+        logs = self.cluster_api.read_job_logs('myjob')
+        self.assertEqual(logs, self.cluster_api.read_pod_logs.return_value)
+        self.cluster_api.get_most_recent_pod_for_job.assert_called_with('myjob')
+        self.cluster_api.read_pod_logs.assert_called_with('myjob-abcd')
+
+    def test_get_most_recent_pod_for_job_name__no_pods_found(self):
+        self.cluster_api.list_pods = Mock()
+        self.cluster_api.list_pods.return_value = []
+        with self.assertRaises(ItemNotFoundException) as raised_exception:
+            self.cluster_api.get_most_recent_pod_for_job('myjob')
+        self.assertEqual(str(raised_exception.exception), 'No pods found with job name myjob.')
+
+    def test_get_most_recent_pod_for_job_name__finds_pod(self):
+        pod1 = Mock()
+        pod1.metadata.creation_timestamp = parse("2012-01-01 12:30:00")
+        pod2 = Mock()
+        pod2.metadata.creation_timestamp = parse("2012-01-01 12:50:00")
+        pod3 = Mock()
+        pod3.metadata.creation_timestamp = parse("2012-01-01 12:40:00")
+        self.cluster_api.list_pods = Mock()
+        self.cluster_api.list_pods.return_value = [
+            pod1, pod2, pod3
+        ]
+        pod = self.cluster_api.get_most_recent_pod_for_job('myjob')
+        self.assertEqual(pod, pod2)
 
 class TestContainer(TestCase):
     def test_minimal_create(self):

--- a/lando/k8s/tests/test_watcher.py
+++ b/lando/k8s/tests/test_watcher.py
@@ -174,7 +174,7 @@ class TestJobWatcher(TestCase):
         watcher = JobWatcher(config=Mock())
         watcher.get_most_recent_pod_for_job = Mock()
         mock_pod = Mock()
-        mock_pod.metdata.name = 'myjob-pod'
+        mock_pod.metadata.name = 'myjob-pod'
         watcher.get_most_recent_pod_for_job.return_value = mock_pod
         watcher.lando_client = Mock()
 
@@ -218,14 +218,16 @@ class TestJobWatcher(TestCase):
     def test_on_job_failed_record_output(self, mock_cluster_api):
         mock_cluster_api.return_value.read_pod_logs.return_value = "Error details"
         watcher = JobWatcher(config=Mock())
+        mock_pod = Mock()
         watcher.get_most_recent_pod_for_job = Mock()
-        watcher.get_most_recent_pod_for_job.return_value = Mock()
+        watcher.get_most_recent_pod_for_job.return_value = mock_pod
         watcher.lando_client = Mock()
 
         watcher.on_job_failed('myjob', '31', JobStepTypes.RECORD_OUTPUT_PROJECT)
 
         payload = watcher.lando_client.job_step_error.call_args[0][0]
         message = watcher.lando_client.job_step_error.call_args[0][1]
+        mock_cluster_api.return_value.read_pod_logs.assert_called_with(mock_pod.metadata.name)
         self.assertEqual(payload.job_id, '31')
         self.assertEqual(payload.error_command, JobCommands.RECORD_OUTPUT_PROJECT_ERROR)
         self.assertEqual(message, 'Error details')

--- a/lando/k8s/tests/test_watcher.py
+++ b/lando/k8s/tests/test_watcher.py
@@ -224,5 +224,3 @@ class TestJobWatcher(TestCase):
             self.assertEqual(payload.error_command, JobCommands.STAGE_JOB_ERROR)
             self.assertEqual(message, 'Unable to read logs.')
             mock_logging.error.assert_called_with('Unable to read logs (404)\nReason: Logs not found\n')
-
-

--- a/lando/k8s/tests/test_watcher.py
+++ b/lando/k8s/tests/test_watcher.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
-from unittest.mock import Mock, patch, ANY
+from unittest.mock import Mock, patch
 from lando.k8s.watcher import JobWatcher, JobLabels, JobStepTypes, JobCommands, JobConditionType, ApiException, \
-    EventTypes
+    EventTypes, PodNotFoundException
+from dateutil.parser import parse
 
 
 class TestJobWatcher(TestCase):
@@ -171,10 +172,15 @@ class TestJobWatcher(TestCase):
     def test_on_job_failed(self, mock_cluster_api):
         mock_cluster_api.return_value.read_pod_logs.return_value = "Error details"
         watcher = JobWatcher(config=Mock())
+        watcher.get_most_recent_pod_for_job = Mock()
+        mock_pod = Mock()
+        mock_pod.metdata.name = 'myjob-pod'
+        watcher.get_most_recent_pod_for_job.return_value = mock_pod
         watcher.lando_client = Mock()
 
         watcher.on_job_failed('myjob', '31', JobStepTypes.STAGE_DATA)
-        mock_cluster_api.return_value.read_pod_logs.assert_called_with('myjob')
+        watcher.get_most_recent_pod_for_job.assert_called_with('myjob')
+        mock_cluster_api.return_value.read_pod_logs.assert_called_with('myjob-pod')
         payload = watcher.lando_client.job_step_error.call_args[0][0]
         message = watcher.lando_client.job_step_error.call_args[0][1]
         self.assertEqual(payload.job_id, '31')
@@ -212,6 +218,8 @@ class TestJobWatcher(TestCase):
     def test_on_job_failed_record_output(self, mock_cluster_api):
         mock_cluster_api.return_value.read_pod_logs.return_value = "Error details"
         watcher = JobWatcher(config=Mock())
+        watcher.get_most_recent_pod_for_job = Mock()
+        watcher.get_most_recent_pod_for_job.return_value = Mock()
         watcher.lando_client = Mock()
 
         watcher.on_job_failed('myjob', '31', JobStepTypes.RECORD_OUTPUT_PROJECT)
@@ -227,6 +235,8 @@ class TestJobWatcher(TestCase):
     def test_on_job_failed_reading_logs_failed(self, mock_logging, mock_cluster_api):
             mock_cluster_api.return_value.read_pod_logs.side_effect = ApiException(status=404, reason='Logs not found')
             watcher = JobWatcher(config=Mock())
+            watcher.get_most_recent_pod_for_job = Mock()
+            watcher.get_most_recent_pod_for_job.return_value = Mock()
             watcher.lando_client = Mock()
 
             watcher.on_job_failed('myjob', '31', JobStepTypes.STAGE_DATA)
@@ -236,3 +246,26 @@ class TestJobWatcher(TestCase):
             self.assertEqual(payload.error_command, JobCommands.STAGE_JOB_ERROR)
             self.assertEqual(message, 'Unable to read logs.')
             mock_logging.error.assert_called_with('Unable to read logs (404)\nReason: Logs not found\n')
+
+    @patch('lando.k8s.watcher.ClusterApi')
+    def test_get_most_recent_pod_for_job_name__no_pods_found(self, mock_cluster_api):
+        mock_cluster_api.return_value.list_pods.return_value = []
+        watcher = JobWatcher(config=Mock())
+        with self.assertRaises(PodNotFoundException) as raised_exception:
+            watcher.get_most_recent_pod_for_job('myjob')
+        self.assertEqual(str(raised_exception.exception), 'No pods found with job name myjob.')
+
+    @patch('lando.k8s.watcher.ClusterApi')
+    def test_get_most_recent_pod_for_job_name__finds_pod(self, mock_cluster_api):
+        pod1 = Mock()
+        pod1.metadata.creation_timestamp = parse("2012-01-01 12:30:00")
+        pod2 = Mock()
+        pod2.metadata.creation_timestamp = parse("2012-01-01 12:50:00")
+        pod3 = Mock()
+        pod3.metadata.creation_timestamp = parse("2012-01-01 12:40:00")
+        mock_cluster_api.return_value.list_pods.return_value = [
+            pod1, pod2, pod3
+        ]
+        watcher = JobWatcher(config=Mock())
+        pod = watcher.get_most_recent_pod_for_job('myjob')
+        self.assertEqual(pod, pod2)

--- a/lando/k8s/watcher.py
+++ b/lando/k8s/watcher.py
@@ -89,7 +89,7 @@ class JobWatcher(object):
     def on_job_failed(self, job_name, bespin_job_id, bespin_job_step):
         try:
             pod = self.get_most_recent_pod_for_job(job_name)
-            logs = self.cluster_api.read_pod_logs(pod.metdata.name)
+            logs = self.cluster_api.read_pod_logs(pod.metadata.name)
         except (ApiException, PodNotFoundException) as ex:
             logging.error("Unable to read logs {}".format(str(ex)))
             logs = "Unable to read logs."


### PR DESCRIPTION
The lando k8s job watcher code was attempting to read logs for a failed job by finding a pod with the `job_name`. This failed to find a pod and always returned `Unable to read logs`. Changes here read the logs from the most recent pod created by a failed job.

Fixes 204